### PR TITLE
Move <sys/time.h> into platform-specific files

### DIFF
--- a/ios/pal_config.h
+++ b/ios/pal_config.h
@@ -29,4 +29,6 @@ UTIL_SavePath(
    VOID
 );
 
+#include <sys/time.h>
+
 #endif

--- a/video.c
+++ b/video.c
@@ -20,9 +20,6 @@
 //
 
 #include "main.h"
-#if defined(__IOS__) || defined(__EMSCRIPTEN__)
-#include <sys/time.h>
-#endif
 
 // Screen buffer
 SDL_Surface              *gpScreen           = NULL;


### PR DESCRIPTION
Since we have platform-specific header files, it it better to move such platform-dependent includes into such files.