### PR TITLE
Add AVI support for PAL98 on WIN32 platform, original code from CodeP…

### DIFF
--- a/aviplay.c
+++ b/aviplay.c
@@ -1,0 +1,95 @@
+#undef _NDEBUG
+#include <assert.h>
+
+#include "main.h"
+
+#if defined(_WIN32)
+
+#include <vfw.h>
+#include <SDL.h>
+#include <SDL_syswm.h>
+
+int PAL_PlayAVI(const char *szFilename) {
+        SDL_SysWMinfo wm;
+        HWND hw;
+        DWORD len, starttime;
+        Uint32 prevw, prevh, curw, curh;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	extern SDL_Window *gpWindow;
+#else
+	extern SDL_Surface *gpScreenReal;
+#endif
+	static BOOL aviDisabled = FALSE;
+
+	if(aviDisabled) return -1;
+
+        SDL_VERSION(&wm.version);
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+        SDL_GetWindowWMInfo(gpWindow, &wm);
+        hw = MCIWndCreate(wm.info.win.window, (HINSTANCE)GetModuleHandle(NULL),
+                WS_CHILD | WS_VISIBLE | MCIWNDF_NOMENU | MCIWNDF_NOPLAYBAR | MCIWNDF_NOERRORDLG, NULL);
+#else
+	SDL_GetWMInfo(&wm);
+        hw = MCIWndCreate(wm.window, (HINSTANCE)GetModuleHandle(NULL),
+                WS_CHILD | WS_VISIBLE | MCIWNDF_NOMENU | MCIWNDF_NOPLAYBAR | MCIWNDF_NOERRORDLG, NULL);
+#endif
+
+
+        if (aviDisabled = (hw == NULL)) return -1;
+
+        if (MCIWndOpen(hw, szFilename, 0) != 0) {
+		aviDisabled = TRUE;
+                MCIWndDestroy(hw);
+                return -1;
+        }
+
+        SDL_FillRect(gpScreen, NULL, 0);
+        VIDEO_UpdateScreen(NULL);
+
+        MCIWndSetZoom(hw, 100);
+        MCIWndPlay(hw);
+
+        PAL_ClearKeyState();
+        len = MCIWndGetLength(hw) * (1000 / 15);
+        starttime = SDL_GetTicks();
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	SDL_GetWindowSize(gpWindow, &curw, &curh);
+#else
+        curw = gpScreenReal->w;
+        curh = gpScreenReal->h;
+#endif
+
+	prevw = curw;
+	prevh = curh;
+        MoveWindow(hw, 0, 0, curw, curh, TRUE);
+
+        while (SDL_GetTicks() - starttime < len) {
+                if (g_InputState.dwKeyPress != 0) break;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		SDL_GetWindowSize(gpWindow, &curw, &curh);
+#else
+		curw = gpScreenReal->w;
+		curh = gpScreenReal->h;
+#endif
+                if (prevw != curw || prevh != curh) {
+                        MoveWindow(hw, 0, 0, curw, curh, TRUE);
+                        prevw = curw;
+                        prevh = curh;
+                }
+                UTIL_Delay(500);
+        }
+
+        PAL_ClearKeyState();
+
+        MCIWndStop(hw);
+        MCIWndDestroy(hw);
+
+        return 0;
+}
+#else
+int PAL_PlayAVI(const char *szFilename) {
+	return -1;
+}
+#endif
+

--- a/aviplay.c
+++ b/aviplay.c
@@ -87,9 +87,5 @@ int PAL_PlayAVI(const char *szFilename) {
 
         return 0;
 }
-#else
-int PAL_PlayAVI(const char *szFilename) {
-	return -1;
-}
 #endif
 

--- a/aviplay.h
+++ b/aviplay.h
@@ -1,0 +1,12 @@
+//
+// Copyright (c) 2011, Wei Mingzhi <whistler_wmz@users.sf.net>.
+// All rights reserved.
+//
+
+#ifndef AVIPLAY_H
+#define AVIPLAY_H
+
+int PAL_PlayAVI(const char *szFilename);
+
+#endif
+

--- a/aviplay.h
+++ b/aviplay.h
@@ -6,7 +6,11 @@
 #ifndef AVIPLAY_H
 #define AVIPLAY_H
 
+#ifdef WIN32
 int PAL_PlayAVI(const char *szFilename);
+#else
+inline PAL_PlayAVI(const char *ignored) { return -1; }
+#endif
 
 #endif
 

--- a/ending.c
+++ b/ending.c
@@ -434,6 +434,8 @@ PAL_EndingScreen(
    VOID
 )
 {
+	if(gConfig.fIsWIN95 && PAL_PlayAVI(PAL_PREFIX "6.avi") == 0)  return;
+
 	AUDIO_PlayMusic(0x1a, TRUE, 0);
 	PAL_RNGPlay(gpGlobals->iCurPlayingRNG, 110, 150, 7);
 	PAL_RNGPlay(gpGlobals->iCurPlayingRNG, 151, 999, 9);

--- a/main.c
+++ b/main.c
@@ -206,6 +206,8 @@ PAL_TrademarkScreen(
 
 --*/
 {
+   if(gConfig.fIsWIN95 && PAL_PlayAVI(PAL_PREFIX "1.avi") == 0) return;
+
    PAL_SetPalette(3, FALSE);
    PAL_RNGPlay(6, 0, 1000, 25);
    UTIL_Delay(1000);
@@ -231,6 +233,8 @@ PAL_SplashScreen(
 
 --*/
 {
+   if(gConfig.fIsWIN95 && PAL_PlayAVI(PAL_PREFIX "2.avi") == 0) return;
+
    SDL_Color     *palette = PAL_GetPalette(1, FALSE);
    SDL_Color      rgCurrentPalette[256];
    SDL_Surface   *lpBitmapDown, *lpBitmapUp;

--- a/main.h
+++ b/main.h
@@ -50,6 +50,7 @@
 #include "play.h"
 #include "game.h"
 #include "midi.h"
+#include "aviplay.h"
 
 VOID
 PAL_Shutdown(

--- a/script.c
+++ b/script.c
@@ -2894,6 +2894,7 @@ PAL_InterpretInstruction(
       // Quit game
       //
       if (gConfig.fIsWIN95)
+	 PAL_PlayAVI(PAL_PREFIX "4.avi") == 0 && PAL_PlayAVI(PAL_PREFIX "5.avi") == 0;
          PAL_EndingScreen();
       PAL_AdditionalCredits();
       PAL_Shutdown(0);

--- a/uigame.c
+++ b/uigame.c
@@ -142,6 +142,8 @@ PAL_OpeningMenu(
    AUDIO_PlayMusic(0, FALSE, 1);
    PAL_FadeOut(1);
 
+   if(wItemSelected == 0 && gConfig.fIsWIN95) PAL_PlayAVI(PAL_PREFIX "3.avi");
+
    return (INT)wItemSelected;
 }
 

--- a/video.c
+++ b/video.c
@@ -37,7 +37,8 @@ static SDL_Rect           gTextureRect;
 #endif
 
 // The real screen surface
-static SDL_Surface       *gpScreenReal       = NULL;
+// Make it global, AVI play in SDL v1 will use it
+SDL_Surface       *gpScreenReal       = NULL;
 
 volatile BOOL g_bRenderPaused = FALSE;
 

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -18,7 +18,7 @@ TEST_OBJFILES = $(TEST_CPPFILES:.cpp=.o)
 override CCFLAGS += `sdl2-config --cflags` -g -msse -Wall -O2 -fno-strict-aliasing -I. -I../ -I../liboggvorbis/include -I../liboggvorbis/src -DPAL_HAS_PLATFORM_SPECIFIC_UTILS $(TEST_CCFLAGS)
 CXXFLAGS = $(CCFLAGS) -std=c++11
 CFLAGS = $(CCFLAGS) -std=gnu99
-LDFLAGS = `sdl2-config --libs` -lm -lwinmm -lole32 -loleaut32 -limm32 -lcomctl32 -luuid -ldxguid -lversion -static -static-libgcc -static-libstdc++
+LDFLAGS = `sdl2-config --libs` -lm -lwinmm -lole32 -loleaut32 -limm32 -lcomctl32 -luuid -ldxguid -lvfw32 -lversion -static -static-libgcc -static-libstdc++
 TEST_CXXFLAGS += -isystem $(GTEST_DIR)/include -I $(GTEST_DIR) -g -Wall -Wextra -pthread
 
 .PHONY : all clean check

--- a/win32/Makefile.mingw
+++ b/win32/Makefile.mingw
@@ -18,7 +18,7 @@ TEST_OBJFILES = $(TEST_CPPFILES:.cpp=.o)
 override CCFLAGS += -g -msse -Wall -O2 -fno-strict-aliasing -I. -I../ -I../liboggvorbis/include -I../liboggvorbis/src -DPAL_HAS_PLATFORM_SPECIFIC_UTILS $(TEST_CCFLAGS)
 CXXFLAGS = $(CCFLAGS) -std=c++11
 CFLAGS = $(CCFLAGS) -std=gnu99
-LDFLAGS = -lmingw32 -lSDL2main -lSDL2 -mwindows -lm -lwinmm -lole32 -loleaut32 -limm32 -lcomctl32 -luuid -ldxguid -lversion -static -static-libgcc -static-libstdc++
+LDFLAGS += -lmingw32 -lSDL2main -lSDL2 -mwindows -lm -lwinmm -lole32 -loleaut32 -limm32 -lcomctl32 -luuid -ldxguid -lvfw32 -lversion -static -static-libgcc -static-libstdc++
 TEST_CXXFLAGS += -isystem $(GTEST_DIR)/include -I $(GTEST_DIR) -g -Wall -Wextra -pthread
 
 .PHONY : all clean check

--- a/win32/sdlpal.vcxproj
+++ b/win32/sdlpal.vcxproj
@@ -396,6 +396,7 @@
     <ClCompile Include="..\uigame.c" />
     <ClCompile Include="..\util.c" />
     <ClCompile Include="..\video.c" />
+    <ClCompile Include="..\avplay.c" />
     <ClCompile Include="..\yj1.c" />
     <ClCompile Include="..\adplug\binfile.cpp" />
     <ClCompile Include="..\adplug\binio.cpp" />

--- a/win32/sdlpal.vcxproj
+++ b/win32/sdlpal.vcxproj
@@ -396,7 +396,7 @@
     <ClCompile Include="..\uigame.c" />
     <ClCompile Include="..\util.c" />
     <ClCompile Include="..\video.c" />
-    <ClCompile Include="..\avplay.c" />
+    <ClCompile Include="..\aviplay.c" />
     <ClCompile Include="..\yj1.c" />
     <ClCompile Include="..\adplug\binfile.cpp" />
     <ClCompile Include="..\adplug\binio.cpp" />

--- a/win32/sdlpal.vcxproj
+++ b/win32/sdlpal.vcxproj
@@ -144,7 +144,7 @@
       <Culture>0x0804</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;winmm.lib;sdl2.lib;sdl2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vfw32.lib;comctl32.lib;winmm.lib;sdl2.lib;sdl2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
@@ -173,7 +173,7 @@
       <Culture>0x0804</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;winmm.lib;sdl2.lib;sdl2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vfw32.lib;comctl32.lib;winmm.lib;sdl2.lib;sdl2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -204,7 +204,7 @@
       <Culture>0x0804</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;winmm.lib;sdl2.lib;sdl2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vfw32.lib;comctl32.lib;winmm.lib;sdl2.lib;sdl2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
@@ -236,7 +236,7 @@
       <Culture>0x0804</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;winmm.lib;sdl2.lib;sdl2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vfw32.lib;comctl32.lib;winmm.lib;sdl2.lib;sdl2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>
@@ -267,7 +267,7 @@
       <Culture>0x0804</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;winmm.lib;sdl2.lib;sdl2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vfw32.lib;comctl32.lib;winmm.lib;sdl2.lib;sdl2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
@@ -296,7 +296,7 @@
       <Culture>0x0804</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;winmm.lib;sdl2.lib;sdl2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vfw32.lib;comctl32.lib;winmm.lib;sdl2.lib;sdl2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
把CodePlex上的sdlpal95中有对98柔情版AVI动画的支持（Win32平台）添加进当前代码，使用mingw32编译后测试可用