### PR TITLE
fix crashing in DOS version when language file specified

### DIFF
--- a/font.c
+++ b/font.c
@@ -85,14 +85,15 @@ static void PAL_LoadEmbeddedFont(void)
 
 	//
 	// Convert characters into unicode
+	// Explictly specify BIG5 here for compatibility with codepage auto-detection
 	//
-	nChars = PAL_MultiByteToWideChar(char_buf, nBytes, NULL, 0);
+	nChars = PAL_MultiByteToWideCharCP(CP_BIG5, char_buf, nBytes, NULL, 0);
 	if (NULL == (wchar_buf = (wchar_t *)malloc(nChars * sizeof(wchar_t))))
 	{
 		free(char_buf);
 		return;
 	}
-	PAL_MultiByteToWideChar(char_buf, nBytes, wchar_buf, nChars);
+	PAL_MultiByteToWideCharCP(CP_BIG5, char_buf, nBytes, wchar_buf, nChars);
 	free(char_buf);
 
 	//

--- a/global.c
+++ b/global.c
@@ -233,10 +233,9 @@ PAL_InitGlobals(
    if (!PAL_IsWINVersion(&gConfig.fIsWIN95)) return -1;
 
    //
-   // Detect game language no matter whether message file specified; or DOS version + message file
-   // will crash when loading wor16.fon, since the default UTF-8 is used for converting wor16.asc.
+   // Detect game language only when no message file specified
    //
-   PAL_SetCodePage(PAL_DetectCodePage());
+   if (!gConfig.pszMsgFile) PAL_SetCodePage(PAL_DetectCodePage());
 
    //
    // Set decompress function

--- a/global.c
+++ b/global.c
@@ -233,9 +233,10 @@ PAL_InitGlobals(
    if (!PAL_IsWINVersion(&gConfig.fIsWIN95)) return -1;
 
    //
-   // Detect game language only when no message file specified
+   // Detect game language no matter whether message file specified; or DOS version + message file
+   // will crash when loading wor16.fon, since the default UTF-8 is used for converting wor16.asc.
    //
-   if (!gConfig.pszMsgFile) PAL_SetCodePage(PAL_DetectCodePage());
+   PAL_SetCodePage(PAL_DetectCodePage());
 
    //
    // Set decompress function


### PR DESCRIPTION
Tested with two combination:

1. DOS resources + full paleng31, includes its wor16.asc/wor16.fon modification( unknown what modified )
2. DOS resource + only m_eng.txt from paleng31

both will crash before the fix.
Patch download: https://www.romhacking.net/translations/2441/