### PR TITLE
Android runtime permission request

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         applicationId "io.github.sdlpal"
         minSdkVersion 10
-        targetSdkVersion 12
+        targetSdkVersion 25
         externalNativeBuild {
             ndkBuild {
                 arguments "NDK_APPLICATION_MK:=src/main/cpp/Application.mk"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
         android:label="@string/app_name">
         <activity
             android:name=".MainActivity"
+            android:theme="@style/AppTheme.NoActionBar"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <!-- Android 2.3.3 -->
     <uses-sdk
         android:minSdkVersion="10"
-        android:targetSdkVersion="12" />
+        android:targetSdkVersion="25" />
 
     <!-- OpenGL ES 2.0 -->
     <uses-feature android:glEsVersion="0x00020000" />

--- a/android/app/src/main/java/io/github/sdlpal/MainActivity.java
+++ b/android/app/src/main/java/io/github/sdlpal/MainActivity.java
@@ -10,6 +10,8 @@ import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
+import android.provider.Settings;
+import android.net.Uri;
 
 import java.io.*;
 
@@ -23,12 +25,16 @@ public class MainActivity extends AppCompatActivity {
     private final static int REQUEST_FILESYSTEM_ACCESS_CODE = 101;
     private final AppCompatActivity mActivity = this;
 
-    private void requestForPermissions(boolean exitIfRequestForbidden) {
+    private void requestForPermissions(boolean setupManuallyIfRequestForbidden) {
         if (ActivityCompat.shouldShowRequestPermissionRationale(mActivity, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
             ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE}, REQUEST_FILESYSTEM_ACCESS_CODE);
         } else {
-            if (exitIfRequestForbidden) {
-                System.exit(1);
+            if (setupManuallyIfRequestForbidden) {
+                Intent intent = new Intent();
+                intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                Uri uri = Uri.fromParts("package", getPackageName(), null);
+                intent.setData(uri);
+                startActivity(intent);
             } else {
                 alertUser();
             }
@@ -68,10 +74,9 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M || ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
+    public void onStart() {
+        super.onStart();
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M || ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED ) {
             StartGame();
         } else {
             requestForPermissions(false);

--- a/android/app/src/main/java/io/github/sdlpal/MainActivity.java
+++ b/android/app/src/main/java/io/github/sdlpal/MainActivity.java
@@ -10,7 +10,6 @@ import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
-import android.widget.Toast;
 
 import java.io.*;
 
@@ -23,15 +22,7 @@ public class MainActivity extends AppCompatActivity {
 
     private final static int REQUEST_FILESYSTEM_ACCESS_CODE = 101;
 
-    private boolean checkIfAlreadyhavePermission() {
-        int result = ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
-        if (result == PackageManager.PERMISSION_GRANTED) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-    private void requestForSpecificPermission() {
+    private void requestForPermissions() {
         ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE}, REQUEST_FILESYSTEM_ACCESS_CODE);
     }
 
@@ -49,7 +40,13 @@ public class MainActivity extends AppCompatActivity {
                     builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialogInterface, int i) {
-                            requestForSpecificPermission();
+                            requestForPermissions();
+                        }
+                    });
+                    builder.setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialogInterface, int i) {
+                            System.exit(1);
                         }
                     });
                     builder.create().show();
@@ -61,12 +58,10 @@ public class MainActivity extends AppCompatActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        int MyVersion = Build.VERSION.SDK_INT;
-        if (MyVersion < Build.VERSION_CODES.M || checkIfAlreadyhavePermission())
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M || ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED)
             StartGame();
         else
-            requestForSpecificPermission();
+            requestForPermissions();
     }
 
     public void StartGame() {

--- a/android/app/src/main/java/io/github/sdlpal/MainActivity.java
+++ b/android/app/src/main/java/io/github/sdlpal/MainActivity.java
@@ -1,8 +1,17 @@
 package io.github.sdlpal;
 
+import android.Manifest;
+import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.*;
+import android.support.annotation.NonNull;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
+import android.widget.Toast;
+
 import java.io.*;
 
 public class MainActivity extends AppCompatActivity {
@@ -12,9 +21,55 @@ public class MainActivity extends AppCompatActivity {
 
     public static boolean crashed = false;
 
+    private final static int REQUEST_FILESYSTEM_ACCESS_CODE = 101;
+
+    private boolean checkIfAlreadyhavePermission() {
+        int result = ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        if (result == PackageManager.PERMISSION_GRANTED) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+    private void requestForSpecificPermission() {
+        ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE}, REQUEST_FILESYSTEM_ACCESS_CODE);
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        switch (requestCode) {
+            case REQUEST_FILESYSTEM_ACCESS_CODE:
+                if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    StartGame();
+                } else {
+                    AlertDialog.Builder builder = new AlertDialog.Builder(this);
+                    builder.setMessage(R.string.toast_requestpermission);
+                    builder.setCancelable(false);
+                    builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialogInterface, int i) {
+                            requestForSpecificPermission();
+                        }
+                    });
+                    builder.create().show();
+                }
+                break;
+        }
+    }
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        int MyVersion = Build.VERSION.SDK_INT;
+        if (MyVersion < Build.VERSION_CODES.M || checkIfAlreadyhavePermission())
+            StartGame();
+        else
+            requestForSpecificPermission();
+    }
+
+    public void StartGame() {
 
         System.loadLibrary("SDL2");
         System.loadLibrary("main");

--- a/android/app/src/main/java/io/github/sdlpal/MainActivity.java
+++ b/android/app/src/main/java/io/github/sdlpal/MainActivity.java
@@ -21,9 +21,37 @@ public class MainActivity extends AppCompatActivity {
     public static boolean crashed = false;
 
     private final static int REQUEST_FILESYSTEM_ACCESS_CODE = 101;
+    private final AppCompatActivity mActivity = this;
 
-    private void requestForPermissions() {
-        ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE}, REQUEST_FILESYSTEM_ACCESS_CODE);
+    private void requestForPermissions(boolean exitIfRequestForbidden) {
+        if (ActivityCompat.shouldShowRequestPermissionRationale(mActivity, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE}, REQUEST_FILESYSTEM_ACCESS_CODE);
+        } else {
+            if (exitIfRequestForbidden) {
+                System.exit(1);
+            } else {
+                alertUser();
+            }
+        }
+    }
+
+    private void alertUser() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setMessage(R.string.toast_requestpermission);
+        builder.setCancelable(false);
+        builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialogInterface, int i) {
+                requestForPermissions(true);
+            }
+        });
+        builder.setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialogInterface, int i) {
+                System.exit(1);
+            }
+        });
+        builder.create().show();
     }
 
     @Override
@@ -34,22 +62,7 @@ public class MainActivity extends AppCompatActivity {
                 if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     StartGame();
                 } else {
-                    AlertDialog.Builder builder = new AlertDialog.Builder(this);
-                    builder.setMessage(R.string.toast_requestpermission);
-                    builder.setCancelable(false);
-                    builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-                        @Override
-                        public void onClick(DialogInterface dialogInterface, int i) {
-                            requestForPermissions();
-                        }
-                    });
-                    builder.setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
-                        @Override
-                        public void onClick(DialogInterface dialogInterface, int i) {
-                            System.exit(1);
-                        }
-                    });
-                    builder.create().show();
+                    alertUser();
                 }
                 break;
         }
@@ -58,10 +71,11 @@ public class MainActivity extends AppCompatActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M || ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED)
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M || ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
             StartGame();
-        else
-            requestForPermissions();
+        } else {
+            requestForPermissions(false);
+        }
     }
 
     public void StartGame() {

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -26,4 +26,5 @@
     <string name="action_usefontfile">自訂字體檔案</string>
     <string name="action_usemsgfile">自訂語言檔案</string>
     <string name="action_uselogfile">記錄到檔案</string>
+    <string name="toast_requestpermission">請允許SD卡讀寫，否則程式無法正常運行</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -26,4 +26,5 @@
     <string name="action_uselogfile">记录到文件</string>
     <string name="action_usemsgfile">自定义语言文件</string>
     <string name="action_usefontfile">自定义字体文件</string>
+    <string name="toast_requestpermission">请允许SD卡读写，否则程序无法正常运行</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -26,4 +26,5 @@
     <string name="action_usemsgfile">Customized message file</string>
     <string name="action_usefontfile">Customized font file</string>
     <string name="action_uselogfile">Log to file</string>
+    <string name="toast_requestpermission">Please approve accessing sdcard or app cannot work properly.</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -26,5 +26,5 @@
     <string name="action_usemsgfile">Customized message file</string>
     <string name="action_usefontfile">Customized font file</string>
     <string name="action_uselogfile">Log to file</string>
-    <string name="toast_requestpermission">Please approve accessing sdcard or app cannot work properly.</string>
+    <string name="toast_requestpermission">Please approve sdcard access, or the app will not work properly.</string>
 </resources>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.2'
     }
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Apr 07 22:27:49 CST 2017
+#Wed May 24 14:36:44 CST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip


### PR DESCRIPTION
Starting from Android M, some permissions are not automatically granted during installation. Instead, they should be requested explicitly at runtime.

Needs verify works on old devices:
- [x] Android 2.3.x verified by @PalMusicFan
- [x] Android 4.x verified on 4.4.4 (Visual Studio Emulator for Android)
- [x] Android 5.x verified on 5.0.2 (CMCC M821)
- [x] Android 6.x verified on 6.0.0 (Visual Studio Emulator for Android)
- [x] Android 7.x verified on OPO CM14.1 nightly
