### PR TITLE
Use better colors when playing avi files using SDL 1.2

### DIFF
--- a/aviplay.c
+++ b/aviplay.c
@@ -637,6 +637,7 @@ PAL_RenderAVIFrameToSurface(
     }
 }
 
+
 BOOL
 PAL_PlayAVI(
     LPCSTR     lpszPath
@@ -663,6 +664,8 @@ PAL_PlayAVI(
 	}
 
     PAL_ClearKeyState();
+
+    VIDEO_ChangeDepth(avi->surface->format->BitsPerPixel);
 
 	BOOL       fEndPlay = FALSE;
 	RIFFChunk *buf = (RIFFChunk *)avi->pChunkBuffer;
@@ -738,6 +741,8 @@ PAL_PlayAVI(
         //
         UTIL_Delay(500);
     }
+
+    VIDEO_ChangeDepth(0);
 
 	if (avi->surface != NULL)
 	{

--- a/video.h
+++ b/video.h
@@ -74,6 +74,11 @@ VIDEO_ToggleFullscreen(
 );
 
 VOID
+VIDEO_ChangeDepth(
+   INT             bpp
+);
+
+VOID
 VIDEO_SaveScreenshot(
    VOID
 );


### PR DESCRIPTION
When using SDL 1.2, the game uses 8-bit screen surface. That means that when playing avi files, the video is converted from 16-bit to 8-bit and the current screen palette is used. The result is terrible - the colors are very bad and when playing 3.avi, the screen is black. This change sets a screen palette before playing avi, so the colors are better. The palette is the best as can be while using SDL to convert the video (SDL first converts the pixels to this palette and then to the final palette).