### PR TITLE
Allow language file to specify whether load iso_font

### DIFF
--- a/font.c
+++ b/font.c
@@ -41,6 +41,15 @@ static uint8_t reverseBits(uint8_t x) {
     return y;
 }
 
+static void PAL_LoadISOFont(void)
+{
+    for (int i = 0; i < 0x80; i++)
+    {
+        int j=-1;while(j++<16)unicode_font[i][j]=reverseBits(iso_font[i*15+j]);
+        unicode_font[i][15] = 0;
+    }
+}
+
 static void PAL_LoadEmbeddedFont(void)
 {
 	FILE *fp;
@@ -134,11 +143,7 @@ static void PAL_LoadEmbeddedFont(void)
 
 	fclose(fp);
 
-	for (i = 0; i < 0x80; i++)
-	{
-		int j=-1;while(j++<16)unicode_font[i][j]=reverseBits(iso_font[i*15+j]);
-		unicode_font[i][15] = 0;
-	}
+	PAL_LoadISOFont();
 	_font_height = 15;
 }
 
@@ -256,6 +261,11 @@ PAL_InitFont(
 	if (!cfg->fIsWIN95 && !cfg->pszMsgFile)
 	{
 		PAL_LoadEmbeddedFont();
+	}
+
+	if (g_TextLib.fUseISOFont)
+	{
+		PAL_LoadISOFont();
 	}
 
 	if (cfg->pszFontFile)

--- a/main.c
+++ b/main.c
@@ -79,12 +79,6 @@ PAL_Init(
 
    VIDEO_SetWindowTitle("Loading...");
 
-   e = PAL_InitFont(&gConfig);
-   if (e != 0)
-   {
-      TerminateOnError("Could not load fonts: %d.\n", e);
-   }
-
    e = PAL_InitUI();
    if (e != 0)
    {
@@ -95,6 +89,12 @@ PAL_Init(
    if (e != 0)
    {
       TerminateOnError("Could not initialize text subsystem: %d.\n", e);
+   }
+
+   e = PAL_InitFont(&gConfig);
+   if (e != 0)
+   {
+      TerminateOnError("Could not load fonts: %d.\n", e);
    }
 
    PAL_InitInput();

--- a/text.h
+++ b/text.h
@@ -35,6 +35,33 @@ typedef enum tagDIALOGPOSITION
 
 PAL_C_LINKAGE_BEGIN
 
+typedef struct tagTEXTLIB
+{
+    LPWSTR         *lpWordBuf;
+    LPWSTR         *lpMsgBuf;
+    int           **lpIndexBuf;
+    BOOL            fUseISOFont;
+
+    int             nWords;
+    int             nMsgs;
+    int             nIndices;
+
+    int             nCurrentDialogLine;
+    BYTE            bCurrentFontColor;
+    PAL_POS         posIcon;
+    PAL_POS         posDialogTitle;
+    PAL_POS         posDialogText;
+    BYTE            bDialogPosition;
+    BYTE            bIcon;
+    int             iDelayTime;
+    BOOL            fUserSkip;
+    BOOL            fPlayingRNG;
+
+    BYTE            bufDialogIcons[282];
+} TEXTLIB, *LPTEXTLIB;
+
+extern TEXTLIB         g_TextLib;
+
 extern LPWSTR g_rcCredits[12];
 
 INT

--- a/win32/pal_config.h
+++ b/win32/pal_config.h
@@ -62,4 +62,5 @@
 
 #ifndef __MINGW__
 #define strtok_r strtok_s
+#define strncasecmp _strnicmp
 #endif

--- a/winrt/pal_config.h
+++ b/winrt/pal_config.h
@@ -58,6 +58,7 @@
 #define PAL_IS_PATH_SEPARATOR(x) ((x) == '\\' || (x) == '/')
 
 #define strtok_r strtok_s
+#define strncasecmp _strnicmp
 
 PAL_C_LINKAGE_BEGIN
 


### PR DESCRIPTION
Trying a new way on addressing #52.
Previous we can only specify whether to use the built in ISO_font globally, which looks thicker, looks well for English translation, but not fit other latin translations since it only contains english characters which makes texts of those translations looks sometimes thicker and sometimes thinner. For eliminating the problem, we've completely removed the option, but this font looks really pretty in english translation. In the way of this PR we can let language file maintainers to specify which font to use, currently whether load the ISO_font, in future( once latin BDF/truetype support added) even font files. Which should makes the design more orthogonal.
Usage: add the following lines in the beginning of the english language file(m_eng.txt):
```
[BEGIN SETTING]
UseISOFont=1
[END SETTING]
```