### PR TITLE
Set MIDI volume based on global music volume

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -212,6 +212,7 @@ AUDIO_OpenDevice(
    gAudioDevice.fSoundEnabled = TRUE;
    gAudioDevice.iMusicVolume = gConfig.iMusicVolume * SDL_MIX_MAXVOLUME / PAL_MAX_VOLUME;
    gAudioDevice.iSoundVolume = gConfig.iSoundVolume * SDL_MIX_MAXVOLUME / PAL_MAX_VOLUME;
+   MIDI_SetVolume(gConfig.iMusicVolume);
 
    //
    // Initialize the resampler module
@@ -425,6 +426,7 @@ AUDIO_IncreaseVolume(
    AUDIO_ChangeVolumeByValue(&gConfig.iSoundVolume, 3);
    gAudioDevice.iMusicVolume = gConfig.iMusicVolume * SDL_MIX_MAXVOLUME / PAL_MAX_VOLUME;
    gAudioDevice.iSoundVolume = gConfig.iSoundVolume * SDL_MIX_MAXVOLUME / PAL_MAX_VOLUME;
+   MIDI_SetVolume(gConfig.iMusicVolume);
 }
 
 VOID
@@ -450,6 +452,7 @@ AUDIO_DecreaseVolume(
    AUDIO_ChangeVolumeByValue(&gConfig.iSoundVolume, -3);
    gAudioDevice.iMusicVolume = gConfig.iMusicVolume * SDL_MIX_MAXVOLUME / PAL_MAX_VOLUME;
    gAudioDevice.iSoundVolume = gConfig.iSoundVolume * SDL_MIX_MAXVOLUME / PAL_MAX_VOLUME;
+   MIDI_SetVolume(gConfig.iMusicVolume);
 }
 
 VOID

--- a/macos/native_midi_macosx.c
+++ b/macos/native_midi_macosx.c
@@ -45,7 +45,7 @@ struct _NativeMidiSong
 };
 
 static NativeMidiSong *currentsong = NULL;
-static int latched_volume = 128;
+static int latched_volume = 127;
 
 static OSStatus
 GetSequenceLength(MusicSequence sequence, MusicTimeStamp *_sequenceLength)
@@ -302,7 +302,7 @@ void native_midi_setvolume(NativeMidiSong *song, int volume)
 
     latched_volume = volume;
     if ((song) && (song->audiounit)) {
-        const float floatvol = ((float) volume) / ((float) 128);
+        const float floatvol = ((float) volume) / ((float) 127);
         AudioUnitSetParameter(song->audiounit, kHALOutputParam_Volume,
                               kAudioUnitScope_Global, 0, floatvol, 0);
     }

--- a/midi.c
+++ b/midi.c
@@ -24,6 +24,21 @@
 
 static int  g_iMidiCurrent = -1;
 static NativeMidiSong *g_pMidi = NULL;
+static int  g_iMidiVolume = PAL_MAX_VOLUME;
+
+void
+MIDI_SetVolume(
+	int       iVolume
+)
+{
+#if PAL_HAS_NATIVEMIDI
+	g_iMidiVolume = iVolume;
+	if (g_pMidi)
+	{
+		native_midi_setvolume(g_pMidi, iVolume * 127 / PAL_MAX_VOLUME);
+	}
+#endif
+}
 
 void
 MIDI_Play(
@@ -82,6 +97,7 @@ MIDI_Play(
 
 	if (g_pMidi)
 	{
+		MIDI_SetVolume(g_iMidiVolume);
 		native_midi_start(g_pMidi, fLoop);
 		g_iMidiCurrent = iNumRIX;
 	}

--- a/midi.h
+++ b/midi.h
@@ -29,6 +29,26 @@
 /*++
   Purpose:
 
+    Set volume for MIDI music.
+
+  Parameters:
+
+    [IN]  iVolume - volume in range 0-PAL_MAX_VOLUME.
+
+  Return value:
+
+    None.
+
+--*/
+PAL_C_LINKAGE
+void
+MIDI_SetVolume(
+	int       iVolume
+);
+
+/*++
+  Purpose:
+
     Start playing the specified music in MIDI format.
 
   Parameters:

--- a/native_midi/native_midi.h
+++ b/native_midi/native_midi.h
@@ -156,6 +156,7 @@ int native_midi_active(NativeMidiSong *song);
   Parameters:
 
     [IN]  song - the NativeMidiSong object.
+    [IN]  volume - midi volume in range 0-127.
 
   Return value:
 


### PR DESCRIPTION
The Native MIDI interface has a function native_midi_setvolume to set MIDI volume, but it's never called.
I added setting MIDI volume based on global music volume. And since Native MIDI volume range wasn't defined, I defined it as 0-127, because existing Native MIDI implementations either use this range or use floating point range 0.0-1.0.