### PR TITLE
fix path location issues while launching pal as app or being in a dif…

### DIFF
--- a/macos/pal_config.h
+++ b/macos/pal_config.h
@@ -26,6 +26,10 @@
 #ifndef PAL_CONFIG_H
 # define PAL_CONFIG_H
 
+# ifndef FIX_MACOS_PATH_ISSUE
+#  define FIX_MACOS_PATH_ISSUE
+# endif
+
 # ifndef PAL_HAS_JOYSTICKS
 #  define PAL_HAS_JOYSTICKS    1
 # endif

--- a/main.c
+++ b/main.c
@@ -457,6 +457,29 @@ main(
 	   return g_exit_code;
    }
 
+
+#ifdef FIX_MACOS_PATH_ISSUE
+	//Fix a path bug on macOS
+	char *work_path = strdup(argv[0]);
+
+	int len = strlen(work_path);
+
+
+	while(--len) {
+		if(work_path[len] == '/') {
+			work_path[len] = '\0';
+			break;
+		}
+	}
+
+
+	chdir(work_path);
+
+	free(work_path);
+#endif
+
+
+
 #if !defined(UNIT_TEST) || defined(UNIT_TEST_GAME_INIT)
    //
    // Initialize SDL


### PR DESCRIPTION
通过macOS下配置sdlpal（修改配置文件或者修改.h文件）无法实现把pal.app放在任意地方灵活的双击运行。因为macOS app运行的workpath并不会自动切换到Pal所在目录，导致读取／存取资源文件无法正确找到位置。这个问题无论Relase还是Debug都是存在的。

之前我在sdlpal/sdlpal下面问了这个问题，但是我实验了好久（也许我没有搞对）都无法解决这个问题。

这个patch修改了2个地方， 一个是main.c在PAL_Init()之前将app的workpath切换到当前Pal映像所在目录，另外一个是macos的配置.h文件， 目前只在macOS打开这个选项。