### PR TITLE
Fix 3DS port build error, enable travis-ci for 3DS port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,43 @@ matrix:
           - cd ..
           
       - os: linux
+        env: TARGET=3ds
+        sudo: enabled
+        addons:
+          apt:
+            packages:
+            - unzip
+        before_install:
+          - export PUSHD="$(pwd)"
+          - mkdir -p $CACHE/
+          - cd $CACHE/
+          - wget https://github.com/devkitPro/pacman/releases/download/devkitpro-pacman-1.0.1/devkitpro-pacman.deb
+          - sudo dpkg -i devkitpro-pacman.deb
+          - sudo dkp-pacman -Syu
+          - sudo dkp-pacman -S 3ds-dev --noconfirm
+          - export DEVKITPRO=/opt/devkitpro
+          - export DEVKITARM=/opt/devkitpro/devkitARM
+          - sudo chown $(whoami):$(whoami) /opt/devkitpro
+          - rm -rf SDL-1.2-N3DS
+          - git clone https://github.com/zephray/SDL-1.2-N3DS.git
+          - cd SDL-1.2-N3DS/SDL-1.2.15
+          - cp Makefile.n3ds Makefile
+          - make
+          - make install
+          - wget https://github.com/profi200/Project_CTR/releases/download/0.15/makerom_015_ctrtool.zip
+          - unzip makerom_015_ctrtool.zip
+          - sudo mkdir -p /opt/ctrtool/bin
+          - sudo cp Linux_x86_64/* /opt/ctrtool/bin/
+          - sudo chmod +x /opt/ctrtool/bin/*
+          - export PATH=/opt/ctrtool/bin:$PATH
+          - cd "${PUSHD}"
+        script:
+          - cd 3ds
+          - make
+          - make cia
+          - cp sdlpal.cia ../deploy/sdlpal-3ds.cia
+          
+      - os: linux
         language: android
         env: TARGET=Android SDK_HASH=3859397 NDK_VERSION=r16 TERM=dumb
         cache:

--- a/3ds/Makefile
+++ b/3ds/Makefile
@@ -46,7 +46,7 @@ CFLAGS	:=	-g -Wall -O2 -mword-relocations \
 			-fomit-frame-pointer -ffunction-sections \
 			$(ARCH)
 
-CFLAGS	+=	$(INCLUDE) -DARM11 -D_3DS -D__3DS__ -D__N3DS__ -DPAL_HAS_PLATFORM_SPECIFIC_UTILS -I..
+CFLAGS	+=	$(INCLUDE) -DARM11 -D_3DS -D__3DS__ -D__N3DS__ -DPAL_HAS_PLATFORM_SPECIFIC_UTILS -I.. -I../..
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++14
 

--- a/3ds/Makefile
+++ b/3ds/Makefile
@@ -1,5 +1,3 @@
-export DEVKITPRO=/opt/devkitpro
-export DEVKITARM=/opt/devkitpro/devkitARM
 #---------------------------------------------------------------------------------
 .SUFFIXES:
 #---------------------------------------------------------------------------------
@@ -48,7 +46,7 @@ CFLAGS	:=	-g -Wall -O2 -mword-relocations \
 			-fomit-frame-pointer -ffunction-sections \
 			$(ARCH)
 
-CFLAGS	+=	$(INCLUDE) -DARM11 -D_3DS -D__3DS__ -D__N3DS__ -DPAL_HAS_PLATFORM_SPECIFIC_UTILS -I.
+CFLAGS	+=	$(INCLUDE) -DARM11 -D_3DS -D__3DS__ -D__N3DS__ -DPAL_HAS_PLATFORM_SPECIFIC_UTILS -I..
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++14
 

--- a/adplug/mame/fmopl.cpp.h
+++ b/adplug/mame/fmopl.cpp.h
@@ -429,8 +429,8 @@ public:
 	//attotime TimerBase;         /* Timer base time (==sampling time)*/
 	device_t *device;
 
-	signed int phase_modulation;    /* phase modulation input (SLOT 2) */
-	signed int output[1];
+	int32_t phase_modulation;    /* phase modulation input (SLOT 2) */
+	int32_t output[1];
 #if BUILD_Y8950
 	int32_t output_deltat[4];     /* for Y8950 DELTA-T, chip is mono, that 4 here is just for safety */
 #endif

--- a/adplug/mame/ymf262.cpp.h
+++ b/adplug/mame/ymf262.cpp.h
@@ -1029,7 +1029,7 @@ number   number    BLK/FNUM2 FNUM    Drum  Hat   Drum  Tom  Cymbal
 static inline void chan_calc_rhythm( OPL3 *chip, OPL3_CH *CH, unsigned int noise )
 {
 	OPL3_SLOT *SLOT;
-	signed int *chanout = chip->chanout;
+	int32_t *chanout = chip->chanout;
 	signed int out;
 	unsigned int env;
 
@@ -2627,7 +2627,7 @@ void ymf262_update_one(void *_chip, OPL3SAMPLE /***buffers*/*buffer, int length)
 {
 	int i;
 	OPL3        *chip  = (OPL3 *)_chip;
-	signed int *chanout = chip->chanout;
+	int32_t     *chanout = chip->chanout;
 	uint8_t       rhythm = chip->rhythm&0x20;
 
 	//OPL3SAMPLE  *ch_a = buffers[0];

--- a/docs/README.md
+++ b/docs/README.md
@@ -137,7 +137,7 @@ cd 3ds
 make
 make cia
 ```
-You need to have *DevkitPro ARM* and *SDL 1.2* for 3DS portlib installed. The compiled executable should be generated with the filename *`sdlpal`* at the current directory.
+You need to have *DevkitPro ARM* and *SDL 1.2* for 3DS portlib installed. Creating a CIA package is not required to play the game, but in order to to that, a seperate *makerom* tool is required. The compiled executable should be generated with the filename *`sdlpal`* at the current directory.
  
 Nintendo Wii
 ------------


### PR DESCRIPTION
This should fully fix issue #95 , also fix the Makefile problem mentioned but not fixed in #81. This also enable travis-ci for 3DS port.
GitHub doesn't want to let me reopen the previous PR. I guess I should open a new one instead.