### PR TITLE
(iOS)BugFix: select width row will change smooth switch in Settings

### DIFF
--- a/ios/SDLPal/SDLPal/SettingsTableViewController.m
+++ b/ios/SDLPal/SDLPal/SettingsTableViewController.m
@@ -220,8 +220,6 @@ typedef void(^SelectedBlock)(NSString *selected);
         toggleTouchScreenOverlay.on = !toggleTouchScreenOverlay.isOn;
     }else if( indexPath.section == 2 && indexPath.row == 1 ) { //keep aspect
         toggleKeepAspect.on = !toggleKeepAspect.isOn;
-    }else if( indexPath.section == 2 && indexPath.row == 2 ) { //smooth scaling
-        toggleSmoothScaling.on = !toggleSmoothScaling.isOn;
     }else if( indexPath.section == 3 && indexPath.row == 0 ) { //Enable GLSL
         toggleGLSL.on = !toggleGLSL.isOn;
         [self.tableView reloadData];


### PR DESCRIPTION
BugFix: select width row will change smooth switch in Settings

修复了点选界面宽度那一行后, 更改的是smooth开关的问题(虽然那个开关没有存储逻辑, 是由pszScaleQuality算出, 但是代码会让后续维护人员误解. 所以改掉了)