### PR TITLE
[macOS] Dark♂Mode Support to macOS 10.11-10.13 SDKs.

### DIFF
--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -24,5 +24,7 @@
 	<string>SDLMain</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
macOS Mojave Dark Mode Support against macOS 10.11-10.13 SDKs.

- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
Xcode 10, at this moment, maybe too buggy to compile this project. Using old SDKs with Xcode 9 can compile the project, but the support of Dark♂Mode has to be implemented manually to the info.plist for non-Qt programs.

- [X] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?
No dependency.

- [X] Have you written new tests for your changes?
Yes.

- [X] Have you successfully run it with your changes locally?
Yes

- [ ] Have you tested on following platforms?
  - [ ] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [X] macOS
  - [ ] iOS
  
