### PR TITLE
add the MESSAGE file ext “.txt”

### DIFF
--- a/common.h
+++ b/common.h
@@ -27,6 +27,8 @@
 # define PAL_CLASSIC        1
 #endif
 
+#include "defines.h"
+
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
 #define _CRT_SECURE_NO_WARNINGS
 #endif

--- a/defines.h
+++ b/defines.h
@@ -1,0 +1,30 @@
+/* -*- mode: c; tab-width: 4; c-basic-offset: 4; c-file-style: "linux" -*- */
+//
+// Copyright (c) 2009-2011, Wei Mingzhi <whistler_wmz@users.sf.net>.
+// Copyright (c) 2011-2019, SDLPAL development team.
+// All rights reserved.
+//
+// This file is part of SDLPAL.
+//
+// SDLPAL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef _DEFINES_H
+#define _DEFINES_H
+
+#ifndef PAL_LOCALIZATION_EXT
+# define PAL_LOCALIZATION_EXT "slf"
+#endif
+
+#endif //_DEFINES_H

--- a/ios/SDLPal/SDLPal.xcodeproj/project.pbxproj
+++ b/ios/SDLPal/SDLPal.xcodeproj/project.pbxproj
@@ -372,6 +372,7 @@
 		C66C6CA21ECCB73100CE10C1 /* SDLPal_AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLPal_AppDelegate.h; sourceTree = "<group>"; };
 		C66C6CA31ECCB73100CE10C1 /* SDLPal_AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLPal_AppDelegate.m; sourceTree = "<group>"; };
 		C66F6FD51FB16CB200F3F0DA /* iOS Launch Screen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "iOS Launch Screen.storyboard"; sourceTree = "<group>"; };
+		C67162F422EB2E0D0093995B /* defines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = defines.h; path = ../../../defines.h; sourceTree = "<group>"; };
 		C6743A831ECCAFA700AEF782 /* SettingsTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SettingsTableViewController.m; sourceTree = "<group>"; };
 		C6743A851ECCAFC600AEF782 /* SettingsTableViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsTableViewController.h; sourceTree = "<group>"; };
 		C694CF861EB619660006F937 /* gs_instruments.dls */ = {isa = PBXFileReference; lastKnownFileType = file; name = gs_instruments.dls; path = /System/Library/Components/CoreAudio.component/Contents/Resources/gs_instruments.dls; sourceTree = "<group>"; };
@@ -745,6 +746,7 @@
 		C63505771EA6575200186049 /* Headers */ = {
 			isa = PBXGroup;
 			children = (
+				C67162F422EB2E0D0093995B /* defines.h */,
 				71DCB6951ED9CBB000F120DB /* aviplay.h */,
 				C635056A1EA6570300186049 /* midi.h */,
 				57FB015A1B7A50E0005FCF4C /* codepage.h */,

--- a/ios/SDLPal/SDLPal/Base.lproj/Settings.storyboard
+++ b/ios/SDLPal/SDLPal/Base.lproj/Settings.storyboard
@@ -76,7 +76,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Translation File" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vvj-5L-w4s">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Localization File" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vvj-5L-w4s">
                                                     <rect key="frame" x="8" y="12" width="157" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>

--- a/ios/SDLPal/SDLPal/SettingsTableViewController.m
+++ b/ios/SDLPal/SDLPal/SettingsTableViewController.m
@@ -126,7 +126,7 @@
     availLangPacks = [NSMutableArray new];
     availFonts = [NSMutableArray new];
     availEffects = [NSMutableArray new];
-    NSArray *langpackExtensionList = @[@"txt",@"msg",@"lng"];
+    NSArray *langpackExtensionList = @[@PAL_LOCALIZATION_EXT];
     NSArray *fontExtensionList = @[@"bdf",@"ttf",@"otf",@"ttc"];
     NSArray *effectExtensionList = @[@"glsl",@"glslp"];
     NSString *basePath = [NSString stringWithUTF8String:UTIL_BasePath()];

--- a/unix/unix.cpp
+++ b/unix/unix.cpp
@@ -117,7 +117,7 @@ struct {
    const char* levels;
 } gLabels[3] = {
    { "SDLPAL Launcher",     "Language & Font",    "Display",         "Audio",         "Logging",
-     "Game folder:",        "Message file:",      "Font file:",      "Log file:",     "Log level:",
+     "Game folder:",        "Localization file:",      "Font file:",      "Log file:",     "Log level:",
      "&Touch overlay",      "&Keep aspect ratio", "&Full screen",    "Enable A&VI",   "Enable &GLSL",
      "Enable &HDR",         "Texture size:",      "x ",              "Window size:",  "x ",
      "Shader file:",        "&CD src:",           "&BGM src:",       "&OPL core:",    "O&PL chip:",

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -56,7 +56,7 @@ gtest-all.o : $(GTEST_DIR)/src/gtest-all.cc %.d
 
 %$(INTER).o: %.rc
 	@echo [RES] $^
-	@$(HOST)windres -i $^ -o $@
+	@$(HOST)windres -I.. -i $^ -o $@
 
 $(TEST_TARGET): $(OBJFILES) $(TEST_OBJFILES) gtest-all.o
 	@echo [LD] $@

--- a/win32/sdlpal.rc
+++ b/win32/sdlpal.rc
@@ -1,6 +1,7 @@
 // Microsoft Visual C++ generated resource script.
 //
 #include "resource.h"
+#include "defines.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
 /////////////////////////////////////////////////////////////////////////////
@@ -13,7 +14,7 @@
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// 非特定语言 resources
+// LANG_NEUTRAL resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)
 LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
@@ -40,7 +41,7 @@ BEGIN
     CONTROL         "&Keep aspect ratio",IDC_ASPECTRATIO,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,90,129,72,10
     LTEXT           "BGM source:",IDC_STATIC,14,228,41,8
     CONTROL         "&Full screen start",IDC_FULLSCREEN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,129,67,10
-    EDITTEXT        IDC_MSGFILE,70,56,270,14,ES_AUTOHSCROLL | ES_READONLY
+    EDITTEXT        IDC_MSGFILE,84,56,256,14,ES_AUTOHSCROLL | ES_READONLY
     GROUPBOX        "Audio",IDC_STATIC,7,190,391,85
     COMBOBOX        IDC_CD,57,206,48,30,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     COMBOBOX        IDC_BGM,57,226,48,30,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
@@ -56,7 +57,7 @@ BEGIN
     LTEXT           "Buffer size:",IDC_STATIC,311,229,38,8
     EDITTEXT        IDC_AUDIOBUFFER,351,226,40,14,ES_AUTOHSCROLL | ES_NUMBER
     PUSHBUTTON      "&Browse",IDC_BRGAME,348,7,50,14
-    CONTROL         "Message file:",IDC_USEMSGFILE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,59,56,8
+    CONTROL         "Localization file:",IDC_USEMSGFILE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,59,66,8
     CONTROL         "Enable &touch overlay",IDC_TOUCHOVERLAY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,170,147,80,10
     LTEXT           "Quality:",IDC_STATIC,14,248,26,8
     LTEXT           "Low                              High",IDC_STATIC,31,262,88,8
@@ -67,8 +68,8 @@ BEGIN
     LTEXT           "Sound volume:",IDC_STATIC,256,249,48,8
     LTEXT           "Low                                      High",IDC_STATIC,291,262,104,8
     CONTROL         "",IDC_SOUNDVOLUME,"msctls_trackbar32",WS_TABSTOP,303,248,80,15
-    EDITTEXT        IDC_FONTFILE,70,38,270,14,ES_AUTOHSCROLL | ES_READONLY
-    CONTROL         "Font file:",IDC_USEFONTFILE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,41,56,8
+    EDITTEXT        IDC_FONTFILE,84,38,256,14,ES_AUTOHSCROLL | ES_READONLY
+    CONTROL         "Font file:",IDC_USEFONTFILE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,41,66,8
     GROUPBOX        "Logging",IDC_STATIC,7,80,391,30
     LTEXT           "Log level:",IDC_STATIC,14,95,32,8
     COMBOBOX        IDC_LOGLEVEL,46,92,61,30,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
@@ -202,7 +203,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDC_MSGFILE             "Message file (*.msg)|*.msg|All files (*.*)|*.*||"
+    IDC_MSGFILE             "SDLPal localization file (*." PAL_LOCALIZATION_EXT ")|*." PAL_LOCALIZATION_EXT "|All files (*.*)|*.*||"
     IDC_LOGLEVEL            "Verbose;Debug;Informational;Warning;Error;Fatal"
     IDC_BRFONT              "Select customized font file"
     IDC_FONTFILE            "Font file (*.bdf)|*.bdf|All files (*.*)|*.*||"
@@ -216,12 +217,12 @@ BEGIN
     IDC_SHADERFILE          "GLSLP meta-shaders file(*.glslp)|*.glslp|GLSL shader code file(*.glsl)|*.glsl|All files (*.*)|*.*||"
 END
 
-#endif    // 非特定语言 resources
+#endif    // LANG_NEUTRAL resources
 /////////////////////////////////////////////////////////////////////////////
 
 
 /////////////////////////////////////////////////////////////////////////////
-// 中文(简体，中国) resources
+// GBK resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_CHS)
 LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED
@@ -379,7 +380,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDC_MSGFILE             "语言文件(*.msg)|*.msg|所有文件 (*.*)|*.*||"
+    IDC_MSGFILE             "本地化语言文件(*." PAL_LOCALIZATION_EXT ")|*." PAL_LOCALIZATION_EXT "|所有文件 (*.*)|*.*||"
     IDC_LOGLEVEL            "详细信息;调试信息;运行信息;普通警告;严重错误;致命错误"
     IDC_BRFONT              "选择自定义字体文件"
     IDC_FONTFILE            "字体文件(*.bdf)|*.bdf|所有文件 (*.*)|*.*||"
@@ -393,12 +394,12 @@ BEGIN
     IDC_SHADERFILE          "特效定义文件(*.glslp)|*.glslp|着色器代码文件(*.glsl)|*.glsl|所有文件 (*.*)|*.*||"
 END
 
-#endif    // 中文(简体，中国) resources
+#endif    // GBK resources
 /////////////////////////////////////////////////////////////////////////////
 
 
 /////////////////////////////////////////////////////////////////////////////
-// 中文(繁体，中国台湾) resources
+// BIG5 resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_CHT)
 LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_TRADITIONAL
@@ -530,7 +531,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDC_MSGFILE             "粂ē郎(*.msg)|*.msg|┮Τ郎 (*.*)|*.*||"
+    IDC_MSGFILE             "セて粂ē郎(*." PAL_LOCALIZATION_EXT ")|*." PAL_LOCALIZATION_EXT "|┮Τ郎 (*.*)|*.*||"
     IDC_LOGLEVEL            "冈灿獺;秸刚獺;笲︽獺;炊硄牡;腨岿粇;璓㏑岿粇"
     IDC_BRFONT              "匡拒璹砰郎"
     IDC_FONTFILE            "砰郎(*.bdf)|*.bdf|┮Τ郎 (*.*)|*.*||"
@@ -544,7 +545,7 @@ BEGIN
     IDC_SHADERFILE          "疭﹚竡郎(*.glslp)|*.glslp|帝︹竟絏郎(*.glsl)|*.glsl|┮Τ郎 (*.*)|*.*||"
 END
 
-#endif    // 中文(繁体，中国台湾) resources
+#endif    // BIG5 resources
 /////////////////////////////////////////////////////////////////////////////
 
 

--- a/win32/sdlpal.vcxproj
+++ b/win32/sdlpal.vcxproj
@@ -29,7 +29,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{837BDF47-9375-4C30-866B-07E262E94A01}</ProjectGuid>
     <RootNamespace>sdlpal</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -412,6 +412,7 @@
     <ClInclude Include="..\battle.h" />
     <ClInclude Include="..\codepage.h" />
     <ClInclude Include="..\common.h" />
+    <ClInclude Include="..\defines.h" />
     <ClInclude Include="..\glslp.h" />
     <ClInclude Include="..\liboggvorbis\include\ogg\config_types.h" />
     <ClInclude Include="..\ending.h" />
@@ -530,7 +531,14 @@
     <None Include="..\libmad\sf_table.dat" />
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="sdlpal.rc" />
+    <ResourceCompile Include="sdlpal.rc" >
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Test|Win32'">..</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Test|x64'">..</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..</AdditionalIncludeDirectories>
+    </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
     <Text Include="..\AUTHORS.txt" />

--- a/win32/sdlpal.vcxproj.filters
+++ b/win32/sdlpal.vcxproj.filters
@@ -737,6 +737,9 @@
     <ClInclude Include="..\glslp.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\defines.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\sdlpal.ico">

--- a/winrt/SDLPal.Common/MainPage.xaml.cpp
+++ b/winrt/SDLPal.Common/MainPage.xaml.cpp
@@ -24,7 +24,7 @@ using namespace Windows::UI::Xaml::Input;
 using namespace Windows::UI::Xaml::Media;
 using namespace Windows::UI::Xaml::Navigation;
 
-static Platform::String^ msg_file_exts[] = { ".msg" };
+static Platform::String^ msg_file_exts[] = { "." PAL_LOCALIZATION_EXT };
 static Platform::String^ font_file_exts[] = { ".bdf" };
 static Platform::String^ log_file_exts[] = { ".log" };
 static Platform::String^ shader_file_exts[] = {  ".glslp", ".glsl" };
@@ -319,7 +319,7 @@ void SDLPal::MainPage::Page_Loaded(Platform::Object^ sender, Windows::UI::Xaml::
 #if NTDDI_VERSION >= NTDDI_WIN10
 	if (!Windows::Foundation::Metadata::ApiInformation::IsTypePresent("Windows.UI.ViewManagement.StatusBar")) return;
 #endif
-#if NTDDI_VERSION >= NTDDI_WIN10 || WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+#if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
 	auto statusBar = Windows::UI::ViewManagement::StatusBar::GetForCurrentView();
 	concurrency::create_task(statusBar->ShowAsync()).then([statusBar]() { statusBar->BackgroundOpacity = 1.0; });
 #endif

--- a/winrt/SDLPal.Common/Strings/en/Resources.resw
+++ b/winrt/SDLPal.Common/Strings/en/Resources.resw
@@ -215,7 +215,7 @@ You can use the main menu option inside the game to return to this page.</value>
     <value>Setting finished</value>
   </data>
   <data name="MessageFile.PlaceholderText" xml:space="preserve">
-    <value>No customized message file</value>
+    <value>No customized localization file</value>
   </data>
   <data name="MusicVolume.Header" xml:space="preserve">
     <value>Music volume</value>
@@ -311,7 +311,7 @@ You can use the main menu option inside the game to return to this page.</value>
     <value>Log to file</value>
   </data>
   <data name="UseMessageFile.Content" xml:space="preserve">
-    <value>Customized message file</value>
+    <value>Customized localization file</value>
   </data>
   <data name="Verbose.Content" xml:space="preserve">
     <value>Verbose</value>

--- a/winrt/SDLPal.UWP/SDLPal.Core.vcxproj
+++ b/winrt/SDLPal.UWP/SDLPal.Core.vcxproj
@@ -217,6 +217,7 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\defines.h" />
     <ClInclude Include="..\..\mini_glloader.h" />
     <ClInclude Include="..\..\video_glsl.h" />
     <ClInclude Include="..\..\glslp.h" />

--- a/winrt/SDLPal.UWP/SDLPal.Core.vcxproj.filters
+++ b/winrt/SDLPal.UWP/SDLPal.Core.vcxproj.filters
@@ -450,6 +450,9 @@
     <ClInclude Include="..\..\glslp.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\defines.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\adplug\binfile.cpp">


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
The current MESSAGE files extension is “.msg“. It can be confusing to the user because there is the  original resource file ”M.MSG“. So I think a new extension should be implemented. 
Since the current English translation comes with the MESSAGE File Extension of ".txt", the MESSAGE file extension of “.txt” could be added to the extension filter. 
P.S. There is no "\*.\*" option for the UWP version, so as of now users could not pick ".txt" MESSAGE files. This problem is solved in this PR. 
- [x] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?
No new dependency was introduced. 

- [ ] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [x] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS
  
