### PR TITLE
fixed compilation for GCC

### DIFF
--- a/adplug/mame/fmopl.cpp.h
+++ b/adplug/mame/fmopl.cpp.h
@@ -1089,11 +1089,11 @@ public:
 
 		/* allocate memory block */
 		char *ptr = reinterpret_cast<char *>(::operator new(state_size));
-		std::fill_n(ptr, state_size, 0);
 
 		FM_OPL *const OPL = new(ptr) FM_OPL;
+        memset(OPL, 0, state_size);
 
-		ptr += sizeof(FM_OPL);
+		ptr += state_size;
 
 #if BUILD_Y8950
 		if (type & OPL_TYPE_ADPCM)

--- a/util.c
+++ b/util.c
@@ -961,7 +961,7 @@ UTIL_LogSetPrelude(
 }
 
 #if PAL_NEED_STRCASESTR
-inline char* stoupper(char* s)
+PAL_FORCE_INLINE char* stoupper(const char* s)
 {
 	char* p = strdup(s);
 	char* p1 = p;
@@ -969,8 +969,8 @@ inline char* stoupper(char* s)
 	return p1;
 }
 PAL_C_LINKAGE char* strcasestr(const char *a, const char *b) {
-	const char *a1 = stoupper(a);
-	const char *b1 = stoupper(b);
+	char *a1 = stoupper(a);
+	char *b1 = stoupper(b);
 	char *ptr = strstr(a1, b1);
 	free(a1);
 	free(b1);

--- a/util.c
+++ b/util.c
@@ -972,6 +972,7 @@ PAL_C_LINKAGE char* strcasestr(const char *a, const char *b) {
 	char *a1 = stoupper(a);
 	char *b1 = stoupper(b);
 	char *ptr = strstr(a1, b1);
+	if (ptr != NULL) ptr = (char*)a + (ptr - a1);
 	free(a1);
 	free(b1);
 	return ptr;


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [x] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?
> for changes in util.c: replace `inline` with `PAL_FORCE_INLINE` to avoid problems caused by C compilers that does not recognize `inline`. Also fixed warnings and a wrong logic in strcasestr that returns pointer in free'd memory block.
for changes in fmopl.cpp.h: GCC does uninitialized member check in -O3 level optimization by fill unintialized object memory to non-zero(0xdeadf00d in gdb debug) so that we must zero-intialize the created object even it is created by placement `new`

- [ ] Have you written new tests for your changes?
> these are all compiler-specified changes so that no new tests are required

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [x] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS
  
