### PR TITLE
Partially fix #203

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -186,17 +186,16 @@ jobs:
             if ! [ -d $CACHE/SDL-1.2-N3DS ]
             then
               git clone https://github.com/zephray/SDL-1.2-N3DS.git
-              sed -i 's/GSPGPU_FramebufferFormats/GSPGPU_FramebufferFormat/g' SDL-1.2-N3DS/SDL-1.2.15/src/video/n3ds/SDL_n3dsvideo.h
             fi
           - docker exec -it devkit make -C cache/SDL-1.2-N3DS/SDL-1.2.15 -f Makefile.n3ds install
           - |
             if ! [ -f $CACHE/Linux_x86_64/ctrtool ] || ! [ -f $CACHE/Linux_x86_64/makerom ]
             then
-              wget https://github.com/profi200/Project_CTR/releases/download/0.15/makerom_015_ctrtool.zip
-              unzip -o makerom_015_ctrtool.zip
-              chmod +x Linux_x86_64/*
+              wget https://github.com/3DSGuy/Project_CTR/releases/download/makerom-v0.17/makerom-v0.17-ubuntu_x86_64.zip
+              unzip -o makerom-v0.17-ubuntu_x86_64.zip
+              chmod +x makerom
             fi
-          - docker exec -it devkit cp /cache/Linux_x86_64/{ctrtool,makerom} /opt/devkitpro/tools/bin
+          - docker exec -it devkit cp /cache/makerom /opt/devkitpro/tools/bin
           - cd "${PUSHD}"
         script:
           - cd 3ds

--- a/main.c
+++ b/main.c
@@ -463,7 +463,7 @@ main(
 
   Return value:
 
-    Integer value
+    Integer value.
 
 --*/
 {

--- a/main.c
+++ b/main.c
@@ -463,11 +463,11 @@ main(
 
   Return value:
 
-    Integer value.
+    Integer value.157190
 
 --*/
 {
-#if !defined( __EMSCRIPTEN__ ) && !defined(__WINRT__)
+#if !defined( __EMSCRIPTEN__ ) && !defined(__WINRT__) && !defined(__N3DS__)
    memset(gExecutablePath,0,PAL_MAX_PATH);
    strncpy(gExecutablePath, argv[0], PAL_MAX_PATH);
 #endif

--- a/main.c
+++ b/main.c
@@ -463,7 +463,7 @@ main(
 
   Return value:
 
-    Integer value.157190
+    Integer value
 
 --*/
 {


### PR DESCRIPTION
This partially fix the crash issue in #203, other fixes were done in the SDL port library. This PR also updates the CI script to use newer version of makerom tool. After this fix, the CIA should be able to at least boot to title screen on 2DS/3DS platform, however there are still crashes in the gameplay.

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [ ] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [ ] Have you tested on following platforms?
  - [ ] Win32
  - [ ] UWP
  - [x] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS
  
