### PR TITLE
docs: Fix a few typos

### DIFF
--- a/adplug/mame/fmopl.cpp.h
+++ b/adplug/mame/fmopl.cpp.h
@@ -543,7 +543,7 @@ public:
 				case EG_SUS:    /* sustain phase */
 
 					/* this is important behaviour:
-					one can change percusive/non-percussive modes on the fly and
+					one can change percussive/non-percussive modes on the fly and
 					the chip will remain in sustain phase - verified on real YM3812 */
 
 					if(op.eg_type)     /* non-percussive mode */

--- a/adplug/mame/ymf262.cpp.h
+++ b/adplug/mame/ymf262.cpp.h
@@ -790,7 +790,7 @@ static inline void advance(OPL3 *chip)
 			case EG_SUS:    /* sustain phase */
 
 				/* this is important behaviour:
-				one can change percusive/non-percussive modes on the fly and
+				one can change percussive/non-percussive modes on the fly and
 				the chip will remain in sustain phase - verified on real YM3812 */
 
 				if(op->eg_type)     /* non-percussive mode */

--- a/adplug/rix.h
+++ b/adplug/rix.h
@@ -42,7 +42,7 @@ class CrixPlayer: public CPlayer
   bool load(const std::string &filename, const CFileProvider &fp);
   bool update();
   void rewind(int subsong);
-  void rewindReInit(int subsong, bool reinit); /* For seamless continous */
+  void rewindReInit(int subsong, bool reinit); /* For seamless continuous */
   float getrefresh();
   unsigned int getsubsongs();
 

--- a/adplug/surroundopl.cpp
+++ b/adplug/surroundopl.cpp
@@ -282,7 +282,7 @@ void CSurroundopl::write_opl3(int reg, int val)
 		// generates waveforms to the left channel or the right channel on output
 
 		// Since a OPL3 chip has 18 channels, the higher 9 channels can act as
-		// another OPL2 chip on generateing the harmonic effect. However, the
+		// another OPL2 chip on generating the harmonic effect. However, the
 		// the percussion channels have no counterparts on higher channels,
 		// so they should be treated separately.
 		if ((reg & 0xF) <= 5 || !percussion)

--- a/liboggvorbis/src/block.c
+++ b/liboggvorbis/src/block.c
@@ -196,7 +196,7 @@ static int _vds_shared_init(vorbis_dsp_state *v,vorbis_info *vi,int encp){
   b->transform[0]=_ogg_calloc(VI_TRANSFORMB,sizeof(*b->transform[0]));
   b->transform[1]=_ogg_calloc(VI_TRANSFORMB,sizeof(*b->transform[1]));
 
-  /* MDCT is tranform 0 */
+  /* MDCT is transform 0 */
 
   b->transform[0][0]=_ogg_calloc(1,sizeof(mdct_lookup));
   b->transform[1][0]=_ogg_calloc(1,sizeof(mdct_lookup));

--- a/liboggvorbis/src/envelope.c
+++ b/liboggvorbis/src/envelope.c
@@ -84,7 +84,7 @@ void _ve_envelope_clear(envelope_lookup *e){
   memset(e,0,sizeof(*e));
 }
 
-/* fairly straight threshhold-by-band based until we find something
+/* fairly straight threshold-by-band based until we find something
    that works better and isn't patented. */
 
 static int _ve_amp(envelope_lookup *ve,

--- a/libopusfile/src/http.c
+++ b/libopusfile/src/http.c
@@ -2480,7 +2480,7 @@ static int op_http_stream_open(OpusHTTPStream *_stream,const char *_url,
           ret=op_http_parse_content_range(&range_first,&range_last,
            &range_length,cdr);
           if(OP_UNLIKELY(ret<0))return ret;
-          /*"A response with satus code 206 (Partial Content) MUST NOT
+          /*"A response with status code 206 (Partial Content) MUST NOT
              include a Content-Range field with a byte-range-resp-spec of
              '*'."*/
           if(status_code[2]=='6'
@@ -2782,7 +2782,7 @@ static int op_http_conn_handle_response(OpusHTTPStream *_stream,
       ret=op_http_parse_content_range(&range_first,&range_last,
        &range_length,cdr);
       if(OP_UNLIKELY(ret<0))return ret;
-      /*"A response with satus code 206 (Partial Content) MUST NOT
+      /*"A response with status code 206 (Partial Content) MUST NOT
          include a Content-Range field with a byte-range-resp-spec of
          '*'."*/
       if(OP_UNLIKELY(range_first<0)||OP_UNLIKELY(range_last<0))return OP_FALSE;

--- a/stb_image.h
+++ b/stb_image.h
@@ -5789,7 +5789,7 @@ static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req
       //     Else if n is 128, noop.
       // Endloop
 
-      // The RLE-compressed data is preceeded by a 2-byte data count for each row in the data,
+      // The RLE-compressed data is preceded by a 2-byte data count for each row in the data,
       // which we're going to just skip.
       stbi__skip(s, h * channelCount * 2 );
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -43,7 +43,7 @@ As tests are grouped into test cases in Google Test, please put logically relate
 Step 3
 ------
 
-When you finished writting test codes, you can use ***`make check`*** to compile and run tests. If you are using ***Visual Studio*** under Windows, please make sure you've actived the **Test** configuration before you launch the program.
+When you finished writting test codes, you can use ***`make check`*** to compile and run tests. If you are using ***Visual Studio*** under Windows, please make sure you've activated the **Test** configuration before you launch the program.
 
 ### Special notes for ***Visual Studio*** users
 


### PR DESCRIPTION
There are small typos in:
- adplug/mame/fmopl.cpp.h
- adplug/mame/ymf262.cpp.h
- adplug/rix.h
- adplug/surroundopl.cpp
- liboggvorbis/src/block.c
- liboggvorbis/src/envelope.c
- libopusfile/src/http.c
- stb_image.h
- tests/README.md

Fixes:
- Should read `status` rather than `satus`.
- Should read `percussive` rather than `percusive`.
- Should read `transform` rather than `tranform`.
- Should read `threshold` rather than `threshhold`.
- Should read `preceded` rather than `preceeded`.
- Should read `generating` rather than `generateing`.
- Should read `continuous` rather than `continous`.
- Should read `activated` rather than `actived`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md