### PR TITLE
fix: buffer overflow on font reading

### DIFF
--- a/font.c
+++ b/font.c
@@ -182,6 +182,7 @@ static void PAL_LoadEmbeddedFont(void)
 	for (i = 0; i < nChars; i++)
 	{
 		wchar_t w = (wchar_buf[i] >= unicode_upper_base) ? (wchar_buf[i] - unicode_upper_base + unicode_lower_top) : wchar_buf[i];
+		if (w >= sizeof(unicode_font) / sizeof(unicode_font[0])) { continue; }
 		if (fread(unicode_font[w], 30, 1, fp) == 1)
 		{
 			unicode_font[w][30] = 0;


### PR DESCRIPTION
1. This fixes possible crash in PAL_LoadEmbeddedFont() @ https://github.com/sdlpal/sdlpal/blob/master/font.c#L185
2. Extends unicode font table size to 65536 so that 3rd-party mods can use up to whole ucs-2 table