### PR TITLE
fix NPC follow party BUG

### DIFF
--- a/global.c
+++ b/global.c
@@ -440,6 +440,7 @@ PAL_LoadDefaultGame(
    gpGlobals->wMaxPartyMemberIndex = 0;
    gpGlobals->viewport = PAL_XY(0, 0);
    gpGlobals->wLayer = 0;
+   gpGlobals->nFollower = 0;
    gpGlobals->wChaseRange = 1;
 #ifndef PAL_CLASSIC
    gpGlobals->bBattleSpeed = 2;


### PR DESCRIPTION
**Please answer the following questions in Chinese/English.**
_请使用中文/英文回答以下问题。_

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?
**问：您是否已检查以确保没有其他针对相同更改的打开[拉取请求]（../pulls）？**
_答：是_

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
**问：您是否添加对更改内容的解释，以及为什么希望我们将其包括在内？**
_答：跟随者入队后，gpGlobals->nFollower变为1，此时新建存档（直接读取空的存档位）会带着这个数值新开，故开局就是有一个无图像的NPC跟随的，新建存档后会出现以下问题：_

> 1. 绘制跟随者形象时形象绘制函数报错
> 2. 跟随者形象为一片花屏

_且此问题及其奇怪，有时一直重现这个BUG会一直成功，有时则一次也不会成功。_
_但还是希望能在读取默认数据时将gpGlobals->nFollower置0，提交者在代码中已经做出相应更改。_

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?
**问：此PR中引入了多少依赖项？最低要求是否发生了变化，针对哪个平台？**

- [ ] Have you written new tests for your changes?
**问：您是否为更改编写了新的测试？**

- [ ] Have you successfully run it with your changes locally?
**问：您是否已在本地成功运行更改？**
_答：是。_

- [x] Have you tested on following platforms?
**问：您是否在以下平台上进行了测试？**
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [x] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
**许可：我证明，我有权并同意根据自由软件基金会发布的GNU通用公共许可证第3版（或SDLPAL项目维护者选择的任何更高版本）的条款提交我的贡献。**
