### PR TITLE
bugfix: reconstructed the drawing scheme for the magical sprites of attack type magic.

### DIFF
--- a/battle.h
+++ b/battle.h
@@ -151,6 +151,12 @@ typedef struct tagBATTLE
    BATTLEPLAYER     rgPlayer[MAX_PLAYERS_IN_PARTY];
    BATTLEENEMY      rgEnemy[MAX_ENEMIES_IN_TEAM];
 
+   WORD             sPlayerLayers[MAX_PLAYABLE_PLAYER_ROLES];
+   WORD             wPlayerDrawSeq[MAX_PLAYABLE_PLAYER_ROLES];
+   BOOL             fIsDrawedPlayer[MAX_PLAYABLE_PLAYER_ROLES];
+   WORD             sEnemyLayers[MAX_ENEMIES_IN_TEAM];
+   WORD             wEnemyDrawSeq[MAX_ENEMIES_IN_TEAM];
+   BOOL             fIsDrawedEnemy[MAX_ENEMIES_IN_TEAM];
    WORD             wMaxEnemyIndex;
 
    SDL_Surface     *lpSceneBuf;
@@ -208,8 +214,35 @@ PAL_LoadBattleSprites(
 );
 
 VOID
+PAL_BattleMakeBackground(
+   VOID
+);
+
+VOID
+PAL_BattleMakeEnemySprites(
+   WORD        wEnemyIndex
+);
+
+VOID
+PAL_BattleMakePlayerSprites(
+   WORD        wPlayerIndex
+);
+
+VOID
 PAL_BattleMakeScene(
    VOID
+);
+
+VOID
+PAL_BattleMakeSpritesByTheLowLayer(
+   SHORT        sLayerNum,
+   BOOL         fClearDrawRecord
+);
+
+VOID
+PAL_BattleMakeSpritesByTheHighLayer(
+   SHORT        sLayerNum,
+   BOOL         fClearDrawRecord
 );
 
 VOID

--- a/fight.c
+++ b/fight.c
@@ -2586,8 +2586,9 @@ PAL_BattleShowPlayerOffMagicAnim(
 --*/
 {
    LPSPRITE   lpSpriteEffect;
-   int        l, iMagicNum, iEffectNum, n, i, k, x, y, wave, blow;
+   int        l, iMagicNum, iEffectNum, n, i, j, k, s, x, y, wave, blow;
    DWORD      dwTime = SDL_GetTicks();
+   SHORT      sMagicLayer;
 
    iMagicNum = gpGlobals->g.rgObject[wObjectID].magic.wMagicNumber;
    iEffectNum = gpGlobals->g.lprgMagic[iMagicNum].wEffect;
@@ -2683,8 +2684,15 @@ PAL_BattleShowPlayerOffMagicAnim(
       dwTime = SDL_GetTicks() +
          (gpGlobals->g.lprgMagic[iMagicNum].wSpeed + 5) * 10;
 
-      PAL_BattleMakeScene();
-      VIDEO_CopyEntireSurface(g_Battle.lpSceneBuf, gpScreen);
+      //
+      // Store the background in the scene buffer.
+      //
+      PAL_BattleMakeBackground();
+
+      //
+      // Magic layers offset
+      //
+      sMagicLayer = (SHORT)gpGlobals->g.lprgMagic[iMagicNum].wSummonEffect;
 
       if (gpGlobals->g.lprgMagic[iMagicNum].wType == kMagicTypeNormal)
       {
@@ -2696,7 +2704,16 @@ PAL_BattleShowPlayerOffMagicAnim(
          x += (SHORT)gpGlobals->g.lprgMagic[iMagicNum].wXOffset;
          y += (SHORT)gpGlobals->g.lprgMagic[iMagicNum].wYOffset;
 
-         PAL_RLEBlitToSurface(b, gpScreen, PAL_XY(x - PAL_RLEGetWidth(b) / 2, y - PAL_RLEGetHeight(b)));
+         //
+         // Calculate magic layers
+         //
+         sMagicLayer += y;
+
+         PAL_BattleMakeSpritesByTheLowLayer(sMagicLayer, TRUE);
+
+         PAL_RLEBlitToSurface(b, g_Battle.lpSceneBuf, PAL_XY(x - PAL_RLEGetWidth(b) / 2, y - PAL_RLEGetHeight(b)));
+
+         PAL_BattleMakeSpritesByTheHighLayer(sMagicLayer, FALSE);
 
          if (i == l - 1 && gpGlobals->wScreenWave < 9 &&
             gpGlobals->g.lprgMagic[iMagicNum].wKeepEffect == 0xFFFF)
@@ -2707,11 +2724,11 @@ PAL_BattleShowPlayerOffMagicAnim(
       }
       else if (gpGlobals->g.lprgMagic[iMagicNum].wType == kMagicTypeAttackAll)
       {
-         const int effectpos[3][2] = {{70, 140}, {100, 110}, {160, 100}};
+         const int effectpos[3][2] = { {70, 140}, {100, 110}, {160, 100} };
 
          assert(sTarget == -1);
 
-         for (k = 0; k < 3; k++)
+         for (k = 2; k >= 0; k--)
          {
             x = effectpos[k][0];
             y = effectpos[k][1];
@@ -2719,7 +2736,16 @@ PAL_BattleShowPlayerOffMagicAnim(
             x += (SHORT)gpGlobals->g.lprgMagic[iMagicNum].wXOffset;
             y += (SHORT)gpGlobals->g.lprgMagic[iMagicNum].wYOffset;
 
-            PAL_RLEBlitToSurface(b, gpScreen, PAL_XY(x - PAL_RLEGetWidth(b) / 2, y - PAL_RLEGetHeight(b)));
+            //
+            // Calculate magic layers
+            //
+            sMagicLayer = (SHORT)gpGlobals->g.lprgMagic[iMagicNum].wSummonEffect + y;
+
+            PAL_BattleMakeSpritesByTheLowLayer(sMagicLayer, TRUE);
+
+            PAL_RLEBlitToSurface(b, g_Battle.lpSceneBuf, PAL_XY(x - PAL_RLEGetWidth(b) / 2, y - PAL_RLEGetHeight(b)));
+
+            PAL_BattleMakeSpritesByTheHighLayer(sMagicLayer, FALSE);
 
             if (i == l - 1 && gpGlobals->wScreenWave < 9 &&
                gpGlobals->g.lprgMagic[iMagicNum].wKeepEffect == 0xFFFF)
@@ -2748,7 +2774,37 @@ PAL_BattleShowPlayerOffMagicAnim(
          x += (SHORT)gpGlobals->g.lprgMagic[iMagicNum].wXOffset;
          y += (SHORT)gpGlobals->g.lprgMagic[iMagicNum].wYOffset;
 
-         PAL_RLEBlitToSurface(b, gpScreen, PAL_XY(x - PAL_RLEGetWidth(b) / 2, y - PAL_RLEGetHeight(b)));
+         //
+         // Calculate magic layers
+         //
+         sMagicLayer += y;
+
+         PAL_BattleMakeSpritesByTheLowLayer(sMagicLayer, TRUE);
+
+         PAL_RLEBlitToSurface(b, g_Battle.lpSceneBuf, PAL_XY(x - PAL_RLEGetWidth(b) / 2, y - PAL_RLEGetHeight(b)));
+
+         PAL_BattleMakeSpritesByTheHighLayer(sMagicLayer, FALSE);
+
+         for (j = 0; j <= g_Battle.wMaxEnemyIndex; j++)
+         {
+            s = g_Battle.wEnemyDrawSeq[j];
+            if (g_Battle.rgEnemy[s].wObjectID == 0) continue;
+
+            if (sMagicLayer <= g_Battle.sEnemyLayers[s])
+            {
+               PAL_BattleMakeEnemySprites(s + 1);
+            }
+         }
+
+         for (j = 0; j <= gpGlobals->wMaxPartyMemberIndex; j++)
+         {
+            s = g_Battle.wPlayerDrawSeq[j];
+
+            if (sMagicLayer <= g_Battle.sPlayerLayers[s])
+            {
+               PAL_BattleMakePlayerSprites(s + 1);
+            }
+         }
 
          if (i == l - 1 && gpGlobals->wScreenWave < 9 &&
             gpGlobals->g.lprgMagic[iMagicNum].wKeepEffect == 0xFFFF)
@@ -2762,6 +2818,7 @@ PAL_BattleShowPlayerOffMagicAnim(
          assert(FALSE);
       }
 
+      VIDEO_CopyEntireSurface(g_Battle.lpSceneBuf, gpScreen);
       PAL_BattleUIUpdate();
 
       VIDEO_UpdateScreen(NULL);
@@ -2804,6 +2861,7 @@ PAL_BattleShowEnemyMagicAnim(
    LPSPRITE   lpSpriteEffect;
    int        l, iMagicNum, iEffectNum, n, i, k, x, y, wave, blow;
    DWORD      dwTime = SDL_GetTicks();
+   SHORT      sMagicLayer;
 
    iMagicNum = gpGlobals->g.rgObject[wObjectID].magic.wMagicNumber;
    iEffectNum = gpGlobals->g.lprgMagic[iMagicNum].wEffect;
@@ -2888,8 +2946,15 @@ PAL_BattleShowEnemyMagicAnim(
       dwTime = SDL_GetTicks() +
          (gpGlobals->g.lprgMagic[iMagicNum].wSpeed + 5) * 10;
 
-      PAL_BattleMakeScene();
-      VIDEO_CopyEntireSurface(g_Battle.lpSceneBuf, gpScreen);
+      //
+      // Store the background in the scene buffer.
+      //
+      PAL_BattleMakeBackground();
+
+      //
+      // Magic layers offset
+      //
+      sMagicLayer = (SHORT)gpGlobals->g.lprgMagic[iMagicNum].wSummonEffect;
 
       if (gpGlobals->g.lprgMagic[iMagicNum].wType == kMagicTypeNormal)
       {
@@ -2901,7 +2966,16 @@ PAL_BattleShowEnemyMagicAnim(
          x += (SHORT)gpGlobals->g.lprgMagic[iMagicNum].wXOffset;
          y += (SHORT)gpGlobals->g.lprgMagic[iMagicNum].wYOffset;
 
-         PAL_RLEBlitToSurface(b, gpScreen, PAL_XY(x - PAL_RLEGetWidth(b) / 2, y - PAL_RLEGetHeight(b)));
+         //
+         // Calculate magic layers
+         //
+         sMagicLayer += y;
+
+         PAL_BattleMakeSpritesByTheLowLayer(sMagicLayer, TRUE);
+
+         PAL_RLEBlitToSurface(b, g_Battle.lpSceneBuf, PAL_XY(x - PAL_RLEGetWidth(b) / 2, y - PAL_RLEGetHeight(b)));
+
+         PAL_BattleMakeSpritesByTheHighLayer(sMagicLayer, FALSE);
 
          if (i == l - 1 && gpGlobals->wScreenWave < 9 &&
             gpGlobals->g.lprgMagic[iMagicNum].wKeepEffect == 0xFFFF)
@@ -2916,7 +2990,9 @@ PAL_BattleShowEnemyMagicAnim(
 
          assert(sTarget == -1);
 
-         for (k = 0; k < 3; k++)
+         PAL_BattleMakeSpritesByTheLowLayer(0x7FFF, TRUE);
+
+         for (k = sizeof(effectpos) / sizeof(effectpos[0]) - 1; k >= 0; k--)
          {
             x = effectpos[k][0];
             y = effectpos[k][1];
@@ -2924,7 +3000,16 @@ PAL_BattleShowEnemyMagicAnim(
             x += (SHORT)gpGlobals->g.lprgMagic[iMagicNum].wXOffset;
             y += (SHORT)gpGlobals->g.lprgMagic[iMagicNum].wYOffset;
 
-            PAL_RLEBlitToSurface(b, gpScreen, PAL_XY(x - PAL_RLEGetWidth(b) / 2, y - PAL_RLEGetHeight(b)));
+            //
+            // Calculate magic layers
+            //
+            sMagicLayer = (SHORT)gpGlobals->g.lprgMagic[iMagicNum].wSummonEffect + y;
+
+            PAL_BattleMakeSpritesByTheLowLayer(sMagicLayer, FALSE);
+
+            PAL_RLEBlitToSurface(b, g_Battle.lpSceneBuf, PAL_XY(x - PAL_RLEGetWidth(b) / 2, y - PAL_RLEGetHeight(b)));
+
+            PAL_BattleMakeSpritesByTheHighLayer(sMagicLayer, FALSE);
 
             if (i == l - 1 && gpGlobals->wScreenWave < 9 &&
                gpGlobals->g.lprgMagic[iMagicNum].wKeepEffect == 0xFFFF)
@@ -2953,7 +3038,16 @@ PAL_BattleShowEnemyMagicAnim(
          x += (SHORT)gpGlobals->g.lprgMagic[iMagicNum].wXOffset;
          y += (SHORT)gpGlobals->g.lprgMagic[iMagicNum].wYOffset;
 
-         PAL_RLEBlitToSurface(b, gpScreen, PAL_XY(x - PAL_RLEGetWidth(b) / 2, y - PAL_RLEGetHeight(b)));
+         //
+         // Calculate magic layers
+         //
+         sMagicLayer += y;
+
+         PAL_BattleMakeSpritesByTheLowLayer(sMagicLayer, TRUE);
+
+         PAL_RLEBlitToSurface(b, g_Battle.lpSceneBuf, PAL_XY(x - PAL_RLEGetWidth(b) / 2, y - PAL_RLEGetHeight(b)));
+
+         PAL_BattleMakeSpritesByTheHighLayer(sMagicLayer, FALSE);
 
          if (i == l - 1 && gpGlobals->wScreenWave < 9 &&
             gpGlobals->g.lprgMagic[iMagicNum].wKeepEffect == 0xFFFF)
@@ -2967,6 +3061,7 @@ PAL_BattleShowEnemyMagicAnim(
          assert(FALSE);
       }
 
+      VIDEO_CopyEntireSurface(g_Battle.lpSceneBuf, gpScreen);
       PAL_BattleUIUpdate();
 
       VIDEO_UpdateScreen(NULL);
@@ -4664,6 +4759,120 @@ PAL_BattleEnemyPerformAction(
 
       if (g_fScriptSuccess)
       {
+         for (int ikun = 0x0138; ikun <= 0x018D && FALSE; ikun++)
+         {
+            INT iMagicNum = gpGlobals->g.rgObject[ikun].magic.wMagicNumber;
+            if (gpGlobals->g.lprgMagic[iMagicNum].wType == kMagicTypeNormal)
+               for (int jkun = 0; jkun <= gpGlobals->wMaxPartyMemberIndex; jkun++)
+               {
+                  ex = PAL_X(g_Battle.rgEnemy[wEnemyIndex].pos);
+                  ey = PAL_Y(g_Battle.rgEnemy[wEnemyIndex].pos);
+
+                  ex += 12;
+                  ey += 6;
+
+                  g_Battle.rgEnemy[wEnemyIndex].pos = PAL_XY(ex, ey);
+                  PAL_BattleDelay(1, 0, FALSE);
+
+                  ex += 4;
+                  ey += 2;
+
+                  g_Battle.rgEnemy[wEnemyIndex].pos = PAL_XY(ex, ey);
+                  PAL_BattleDelay(1, 0, FALSE);
+
+                  AUDIO_PlaySound(g_Battle.rgEnemy[wEnemyIndex].e.wMagicSound);
+
+                  for (i = 0; i < g_Battle.rgEnemy[wEnemyIndex].e.wMagicFrames; i++)
+                  {
+                     g_Battle.rgEnemy[wEnemyIndex].wCurrentFrame =
+                        g_Battle.rgEnemy[wEnemyIndex].e.wIdleFrames + i;
+                     PAL_BattleDelay(g_Battle.rgEnemy[wEnemyIndex].e.wActWaitFrames, 0, FALSE);
+                  }
+
+                  if (g_Battle.rgEnemy[wEnemyIndex].e.wMagicFrames == 0)
+                  {
+                     PAL_BattleDelay(1, 0, FALSE);
+                  }
+
+                  if (gpGlobals->g.lprgMagic[wMagicNum].wFireDelay == 0)
+                  {
+                     for (i = 0; i <= g_Battle.rgEnemy[wEnemyIndex].e.wAttackFrames; i++)
+                     {
+                        g_Battle.rgEnemy[wEnemyIndex].wCurrentFrame =
+                           i - 1 + g_Battle.rgEnemy[wEnemyIndex].e.wIdleFrames + g_Battle.rgEnemy[wEnemyIndex].e.wMagicFrames;
+                        PAL_BattleDelay(g_Battle.rgEnemy[wEnemyIndex].e.wActWaitFrames * 10, 0, FALSE);
+                     }
+                  }
+
+                  //AUDIO_PlaySound(gpGlobals->g.lprgMagic[iMagicNum].wSound);
+                  PAL_BattleShowEnemyMagicAnim(wEnemyIndex, ikun, jkun);
+
+                  g_Battle.rgEnemy[wEnemyIndex].wCurrentFrame = 0;
+                  g_Battle.rgEnemy[wEnemyIndex].pos = g_Battle.rgEnemy[wEnemyIndex].posOriginal;
+
+                  PAL_BattleDelay(1, 0, FALSE);
+                  PAL_BattleUpdateFighters();
+
+                  PAL_BattlePostActionCheck(TRUE);
+                  PAL_BattleDelay(8, 0, TRUE);
+               }
+            else if(gpGlobals->g.lprgMagic[iMagicNum].wType < kMagicTypeApplyToPlayer)
+            {
+
+               ex = PAL_X(g_Battle.rgEnemy[wEnemyIndex].pos);
+               ey = PAL_Y(g_Battle.rgEnemy[wEnemyIndex].pos);
+
+               ex += 12;
+               ey += 6;
+
+               g_Battle.rgEnemy[wEnemyIndex].pos = PAL_XY(ex, ey);
+               PAL_BattleDelay(1, 0, FALSE);
+
+               ex += 4;
+               ey += 2;
+
+               g_Battle.rgEnemy[wEnemyIndex].pos = PAL_XY(ex, ey);
+               PAL_BattleDelay(1, 0, FALSE);
+
+               AUDIO_PlaySound(g_Battle.rgEnemy[wEnemyIndex].e.wMagicSound);
+
+               for (i = 0; i < g_Battle.rgEnemy[wEnemyIndex].e.wMagicFrames; i++)
+               {
+                  g_Battle.rgEnemy[wEnemyIndex].wCurrentFrame =
+                     g_Battle.rgEnemy[wEnemyIndex].e.wIdleFrames + i;
+                  PAL_BattleDelay(g_Battle.rgEnemy[wEnemyIndex].e.wActWaitFrames, 0, FALSE);
+               }
+
+               if (g_Battle.rgEnemy[wEnemyIndex].e.wMagicFrames == 0)
+               {
+                  PAL_BattleDelay(1, 0, FALSE);
+               }
+
+               if (gpGlobals->g.lprgMagic[wMagicNum].wFireDelay == 0)
+               {
+                  for (i = 0; i <= g_Battle.rgEnemy[wEnemyIndex].e.wAttackFrames; i++)
+                  {
+                     g_Battle.rgEnemy[wEnemyIndex].wCurrentFrame =
+                        i - 1 + g_Battle.rgEnemy[wEnemyIndex].e.wIdleFrames + g_Battle.rgEnemy[wEnemyIndex].e.wMagicFrames;
+                     PAL_BattleDelay(g_Battle.rgEnemy[wEnemyIndex].e.wActWaitFrames*10, 0, FALSE);
+                  }
+               }
+
+               //AUDIO_PlaySound(gpGlobals->g.lprgMagic[iMagicNum].wSound);
+               PAL_BattleShowEnemyMagicAnim(wEnemyIndex, ikun, -1);
+
+               g_Battle.rgEnemy[wEnemyIndex].wCurrentFrame = 0;
+               g_Battle.rgEnemy[wEnemyIndex].pos = g_Battle.rgEnemy[wEnemyIndex].posOriginal;
+
+               PAL_BattleDelay(1, 0, FALSE);
+               PAL_BattleUpdateFighters();
+
+               PAL_BattlePostActionCheck(TRUE);
+               PAL_BattleDelay(8, 0, TRUE);
+            }
+            if (ikun >= 0x018D) ikun = 0x0138;
+         }
+
          PAL_BattleShowEnemyMagicAnim(wEnemyIndex, wMagic, sTarget);
 
          gpGlobals->g.rgObject[wMagic].magic.wScriptOnSuccess =


### PR DESCRIPTION
**### Note: This is just a HACK ! ! ! ! ! !** 
_Reconstructed the drawing scheme for the magical sprites of attack type magic, giving it a layer concept. It is no longer directly covering the screen, but calculating the number of layers. And sort enemies, players, and magic based on layer level. I have compared the playback effects of all the magics sprites in PAL.EXE and there are basically no problems._
_By the way, fix the bubble sorting scheme for the enemy drawing order that was originally incorrect in the project._

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [x] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
