### PR TITLE
bugfix: reconstructed the drawing scheme for the magical sprites of attack type magic.

### DIFF
--- a/battle.h
+++ b/battle.h
@@ -151,6 +151,12 @@ typedef struct tagBATTLE
    BATTLEPLAYER     rgPlayer[MAX_PLAYERS_IN_PARTY];
    BATTLEENEMY      rgEnemy[MAX_ENEMIES_IN_TEAM];
 
+   WORD             sPlayerLayers[MAX_PLAYABLE_PLAYER_ROLES];
+   WORD             wPlayerDrawSeq[MAX_PLAYABLE_PLAYER_ROLES];
+   BOOL             fIsDrawedPlayer[MAX_PLAYABLE_PLAYER_ROLES];
+   WORD             sEnemyLayers[MAX_ENEMIES_IN_TEAM];
+   WORD             wEnemyDrawSeq[MAX_ENEMIES_IN_TEAM];
+   BOOL             fIsDrawedEnemy[MAX_ENEMIES_IN_TEAM];
    WORD             wMaxEnemyIndex;
 
    SDL_Surface     *lpSceneBuf;
@@ -208,8 +214,35 @@ PAL_LoadBattleSprites(
 );
 
 VOID
+PAL_BattleMakeBackground(
+   VOID
+);
+
+VOID
+PAL_BattleMakeEnemySprites(
+   WORD        wEnemyIndex
+);
+
+VOID
+PAL_BattleMakePlayerSprites(
+   WORD        wPlayerIndex
+);
+
+VOID
 PAL_BattleMakeScene(
    VOID
+);
+
+VOID
+PAL_BattleMakeSpritesByTheLowLayer(
+   SHORT        sLayerNum,
+   BOOL         fClearDrawRecord
+);
+
+VOID
+PAL_BattleMakeSpritesByTheHighLayer(
+   SHORT        sLayerNum,
+   BOOL         fClearDrawRecord
 );
 
 VOID


### PR DESCRIPTION
**### _Note: This is just a HACK ! ! ! ! ! !_** 
_In the original game, casting magic was an action with a layer concept, now it has the same effect as the original.
Reconstructed the drawing scheme for the magical sprites of attack type magic, giving it a layer concept.
It is no longer directly covering the screen, but calculating the number of layers.
And sort enemies, players, and magic based on layer level.
I have compared the playback effects of all the magics sprites in PAL.EXE and there are basically no problems.
By the way, fix the bubble sorting scheme for the enemy drawing order that was originally incorrect in the project.
I am very sorry that the pull request proposed before did not fully upload the change record._


- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [x] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
