### PR TITLE
解决战斗中我方和敌方释放技能，各个形象的渲染顺序不对的问题

### DIFF
--- a/battle.h
+++ b/battle.h
@@ -117,6 +117,26 @@ typedef struct tagBATTLEPLAYER
 #endif
 } BATTLEPLAYER;
 
+typedef enum tagBATTLESPRITETYPE
+{
+   kBattleSpriteTypeNone,
+   kBattleSpriteTypeEnemy,
+   kBattleSpriteTypePlayer,
+   kBattleSpriteTypeMagic,
+} BATTLESPRITETYPE;
+
+typedef struct tagBATTLESPRITESEQ
+{
+   WORD               wType;
+   WORD               wObjectIndex;
+   PAL_POS            pos;
+   SHORT              sLayerOffset;
+   BOOL               fHaveColorShift;
+} BATTLESPRITESEQ;
+
+#define MAX_BATTLE_MAGICSPRITE_ITEMS 3
+#define MAX_BATTLESPRITESEQ_ITEMS (MAX_ENEMIES_IN_TEAM + MAX_PLAYABLE_PLAYER_ROLES + MAX_BATTLE_MAGICSPRITE_ITEMS)
+
 typedef struct tagSUMMON
 {
    LPSPRITE           lpSprite;
@@ -161,6 +181,7 @@ typedef struct tagBATTLE
    LPSPRITE         lpSummonSprite;       // sprite of summoned god
    PAL_POS          posSummon;
    INT              iSummonFrame;         // current frame of the summoned god
+   BOOL             fSummonColorShift;
 
    INT              iExpGained;           // total experience value gained
    INT              iCashGained;          // total cash gained
@@ -182,6 +203,12 @@ typedef struct tagBATTLE
    WORD             wMovingPlayerIndex;   // current moving player index
 
    int              iBlow;
+
+   LPCBITMAPRLE     lpMagicBitmap;        // current magic frame bitmap
+
+   BATTLESPRITESEQ  SpriteDrawSeq[MAX_BATTLESPRITESEQ_ITEMS];
+   WORD             wMaxSpriteDrawSeqIndex;
+   BOOL             fSpriteAddLock;
 
 #ifdef PAL_CLASSIC
    BATTLEPHASE      Phase;
@@ -205,6 +232,74 @@ extern BATTLE g_Battle;
 VOID
 PAL_LoadBattleSprites(
    VOID
+);
+
+VOID
+PAL_BattleDrawBackground(
+   VOID
+);
+
+VOID
+PAL_BattleDrawEnemySprites(
+   WORD              wEnemyIndex,
+   SDL_Surface      *lpDstSurface
+);
+
+VOID
+PAL_BattleDrawPlayerSprites(
+   WORD              wPlayerIndex,
+   SDL_Surface      *lpDstSurface
+);
+
+VOID
+PAL_BattleDrawMagicSprites(
+   INT               iMagicNum,
+   SDL_Surface      *lpDstSurface,
+   PAL_POS           pos
+);
+
+VOID
+PAL_BattleClearSpriteObject(
+   VOID
+);
+
+VOID
+PAL_BattleSpriteAddUnlock(
+   VOID
+);
+
+VOID
+PAL_BattleAddSpriteObject(
+   WORD               wType,
+   WORD               wObjectIndex,
+   PAL_POS            pos,
+   SHORT              sLayerOffset,
+   BOOL               fHaveColorShift
+);
+
+VOID
+PAL_BattleRemoveSpriteObject(
+   WORD               wSpriteObjectIndex
+);
+
+VOID
+PAL_BattleAddFighterSpriteObject(
+   VOID
+);
+
+VOID
+PAL_BattleSortSpriteObjecByPos(
+   VOID
+);
+
+VOID
+PAL_BattleDrawAllSprites(
+   VOID
+);
+
+VOID
+PAL_BattleDrawAllSpritesWithColorShift(
+   BOOL               fColorShift
 );
 
 VOID

--- a/global.h
+++ b/global.h
@@ -347,13 +347,20 @@ typedef enum tagMAGIC_TYPE
    kMagicTypeSummon           = 9,  // summon
 } MAGIC_TYPE;
 
+typedef union tagMAGIC_SPECIAL
+{
+   WORD               wSummonEffect;         // summon effect sprite (in F.MKF)
+   SHORT              sLayerOffset;          // limited to non-summon magic.
+                                             // actual layer: PAL_Y(pos) + wYOffset + wMagicLayerOffset
+} MAGIC_SPECIAL, * LPMAGIC_SPECIAL;
+
 typedef struct tagMAGIC
 {
    WORD               wEffect;               // effect sprite
    WORD               wType;                 // type of this magic
    WORD               wXOffset;
    WORD               wYOffset;
-   WORD               wSummonEffect;         // summon effect sprite (in F.MKF)
+   MAGIC_SPECIAL      rgSpecific;            // have multiple meanings
    SHORT              wSpeed;                // speed of the effect
    WORD               wKeepEffect;           // FIXME: ???
    WORD               wFireDelay;            // start frame of the magic fire stage


### PR DESCRIPTION
**### 测试版本：**
        _DOSBOX Ver 0.72.0.0 中运行仙剑 DOS 版_

**### 测试方法及结果：**
        _将所有仙术的释放和 DOSBOX 下的 PAL.EXE 进行了比对，部分仙术进行了录屏逐帧对比，各种不同敌方组合的情况下仙术渲染全部正确。_

**### 源项目出现的问题：**
        _在原始 PAL 中，不论是敌方还是我方，释放仙术的特效形象都是根据 Y 坐标计算出图层先后顺序，在根据这个图层高度决定每个对象的渲染顺序，并不是像 sdlpal 这样直接按照 4 3 2 1 0 对象索引顺序绘图，这导致了敌方和我方的图层顺序也全是错的。顺便也解决了 Issues #231 的问题。_
        _程序测试结果可参考：https://www.bilibili.com/video/BV16K411a7y6/_

**### 该 PR 的解决方案：**
        _将所有敌人的 Y 坐标和 Y 坐标偏移相加得到图层大小，再根据这组图层数据对敌人的渲染顺序进行排序。_
        _将所有队员的Y坐标当作图层大小进行排序，并把有色调偏移（高光）的队员放在最后进行渲染（图层最高）。_
        _将攻击型非召唤神仙术的 Y 坐标、Y 坐标偏移和图层偏移（其实 wSummonEffect 的另外一个意义就是图层偏移）相加。_
        _渲染过程为两个函数，渲染比指定图层低的形象（一般用于渲染仙术特效之前），另一个是渲染比指定图层高的形象。_
        _注意：这里的敌方和我方是分开渲染的，先渲染敌方，再渲染我方。_

**### 该 PR 的可能的潜在问题：**
        _可能需要更多测试，会不会影响到其他部分，暂时不详_

**### 其他问题：**
        _测试时还发现了其他问题，但应该很好解决，比如 sdlpal 召唤神的坐标与源 PAL.EXE 不同，我方封魔攻击队员时只会重复两遍举剑准备砍的动作帧，而 sdlpal 却重复了三次，我方被大义灭亲本该有受击帧，而 sdlpal 却没有。这些问题将会在以后的 PR 解决。_


- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
