### PR TITLE
fixbug: The pos of summoning gods are different from the original PAL.

### DIFF
--- a/fight.c
+++ b/fight.c
@@ -3058,8 +3058,8 @@ PAL_BattleShowPlayerSummonMagicAnim(
    PAL_MKFDecompressChunk(g_Battle.lpSummonSprite, i, j, gpGlobals->f.fpF);
 
    g_Battle.iSummonFrame = 0;
-   g_Battle.posSummon = PAL_XY(230 + (SHORT)(gpGlobals->g.lprgMagic[wMagicNum].wXOffset),
-      155 + (SHORT)(gpGlobals->g.lprgMagic[wMagicNum].wYOffset));
+   g_Battle.posSummon = PAL_XY(240 + (SHORT)(gpGlobals->g.lprgMagic[wMagicNum].wXOffset),
+      165 + (SHORT)(gpGlobals->g.lprgMagic[wMagicNum].wYOffset));
    g_Battle.sBackgroundColorShift = (SHORT)(gpGlobals->g.lprgMagic[wMagicNum].wEffectTimes);
 
    //


### PR DESCRIPTION
**### 测试版本：**
_DOSBOX Ver 0.72.0.0 中运行仙剑 DOS 版，Pal Windows 95 3.0 补丁 By Yihua Lou。_

**### 测试方法及结果：**
_对 sdlpal 的召唤神与 DOS 版，Win95 版进行了抓图对比，使用 Photoshop 进行像素测量，最终得出 sdlpal 的召唤神 PosX 和PosY 分别比原版少了 10 像素。_

**### 源项目出现的问题：**
_这个问题导致游戏出现了一个最为明显的现象——泰山压住了山神的手......_

**### 该 PR 的解决方案：**
_将 sdlpal 召唤神的 PosX 和 PosY 分别加上了 10 像素......_

**### 附件：**
![SDLPAL](https://github.com/sdlpal/sdlpal/assets/83107010/95374129-dff5-42cc-a82d-85ad34849503)
![DOSBOX](https://github.com/sdlpal/sdlpal/assets/83107010/dfc75415-bd3c-4470-9cff-92c8cb7c4265)



- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
