### PR TITLE
修复装备或使用道具时的队员选择菜单的按键逻辑问题

### DIFF
--- a/uigame.c
+++ b/uigame.c
@@ -1296,7 +1296,7 @@ PAL_ItemUseMenu(
    BYTE           bColor, bSelectedColor;
    PAL_LARGE BYTE bufImage[2048];
    DWORD          dwColorChangeTime;
-   static WORD    wSelectedPlayer = 0;
+   static SHORT   sSelectedPlayer = 0;
    SDL_Rect       rect = {110, 2, 200, 180};
    int            i;
 
@@ -1305,9 +1305,9 @@ PAL_ItemUseMenu(
 
    while (TRUE)
    {
-      if (wSelectedPlayer > gpGlobals->wMaxPartyMemberIndex)
+      if (sSelectedPlayer > gpGlobals->wMaxPartyMemberIndex)
       {
-         wSelectedPlayer = 0;
+         sSelectedPlayer = 0;
       }
 
       //
@@ -1335,7 +1335,7 @@ PAL_ItemUseMenu(
       PAL_DrawText(PAL_GetWord(STATUS_LABEL_FLEERATE), PAL_XY(200, 142),
          ITEMUSEMENU_COLOR_STATLABEL, TRUE, FALSE, FALSE);
 
-      i = gpGlobals->rgParty[wSelectedPlayer].wPlayerRole;
+      i = gpGlobals->rgParty[sSelectedPlayer].wPlayerRole;
 
       PAL_DrawNumber(gpGlobals->g.PlayerRoles.rgwLevel[i], 4, PAL_XY(240, 20),
          kNumColorYellow, kNumAlignRight);
@@ -1370,7 +1370,7 @@ PAL_ItemUseMenu(
       //
       for (i = 0; i <= gpGlobals->wMaxPartyMemberIndex; i++)
       {
-         if (i == wSelectedPlayer)
+         if (i == sSelectedPlayer)
          {
             bColor = bSelectedColor;
          }
@@ -1439,8 +1439,8 @@ PAL_ItemUseMenu(
             // Redraw the selected item.
             //
             PAL_DrawText(
-               PAL_GetWord(gpGlobals->g.PlayerRoles.rgwName[gpGlobals->rgParty[wSelectedPlayer].wPlayerRole]),
-               PAL_XY(125, 16 + 20 * wSelectedPlayer), bSelectedColor, FALSE, TRUE, FALSE);
+               PAL_GetWord(gpGlobals->g.PlayerRoles.rgwName[gpGlobals->rgParty[sSelectedPlayer].wPlayerRole]),
+               PAL_XY(125, 16 + 20 * sSelectedPlayer), bSelectedColor, FALSE, TRUE, FALSE);
          }
 
          PAL_ProcessEvent();
@@ -1460,13 +1460,18 @@ PAL_ItemUseMenu(
 
       if (g_InputState.dwKeyPress & (kKeyUp | kKeyLeft))
       {
-         wSelectedPlayer--;
+         sSelectedPlayer--;
+         if (sSelectedPlayer < 0)
+         {
+            sSelectedPlayer = gpGlobals->wMaxPartyMemberIndex;
+         }
       }
       else if (g_InputState.dwKeyPress & (kKeyDown | kKeyRight))
       {
-         if (wSelectedPlayer < gpGlobals->wMaxPartyMemberIndex)
+         sSelectedPlayer++;
+         if (sSelectedPlayer > gpGlobals->wMaxPartyMemberIndex)
          {
-            wSelectedPlayer++;
+            sSelectedPlayer = 0;
          }
       }
       else if (g_InputState.dwKeyPress & kKeyMenu)
@@ -1475,7 +1480,7 @@ PAL_ItemUseMenu(
       }
       else if (g_InputState.dwKeyPress & kKeySearch)
       {
-         return gpGlobals->rgParty[wSelectedPlayer].wPlayerRole;
+         return gpGlobals->rgParty[sSelectedPlayer].wPlayerRole;
       }
    }
 
@@ -1974,7 +1979,7 @@ PAL_EquipItemMenu(
          iCurrentPlayer--;
          if (iCurrentPlayer < 0)
          {
-            iCurrentPlayer = 0;
+            iCurrentPlayer = gpGlobals->wMaxPartyMemberIndex;
          }
       }
       else if (g_InputState.dwKeyPress & (kKeyDown | kKeyRight))
@@ -1982,7 +1987,7 @@ PAL_EquipItemMenu(
          iCurrentPlayer++;
          if (iCurrentPlayer > gpGlobals->wMaxPartyMemberIndex)
          {
-            iCurrentPlayer = gpGlobals->wMaxPartyMemberIndex;
+            iCurrentPlayer = 0;
          }
       }
       else if (g_InputState.dwKeyPress & kKeyMenu)


### PR DESCRIPTION
**### 测试版本：**
        _DOSBOX Ver 0.72.0.0 中运行仙剑 DOS 版，Pal Windows 95 3.0 补丁 By Yihua Lou。_

**### 测试方法及结果：**
        _对 sdlpal 的装备或使用道具时的队员选择菜单与 DOS 版，Win95 版进行了对比，DOS 版与 Win95 版逻辑相同。_

**### 源项目出现的问题：**
        _光标在第一个选项的时候按上键时，选项光标本该跳到最后一项，但是 sdlpal 按下却是没反应。_
        _下键也是，在末选项上的时候，再按下键本该跳到首选项，sdlpal 按下也没反应。_

**### 该 PR 的解决方案：**
        _对特殊情况进行了特殊处理。_

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [x] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
