### PR TITLE
修复了一些关于仙术菜单、道具菜单和 PlayerInfoBox 菜单的bug

### DIFF
--- a/magicmenu.c
+++ b/magicmenu.c
@@ -279,12 +279,17 @@ PAL_MagicSelectionMenuUpdate(
       if (rgMagicItem[g_iCurrentItem].fEnabled)
       {
          j = g_iCurrentItem % iItemsPerLine;
-		 k = (g_iCurrentItem < iItemsPerLine * iPageLineOffset) ? (g_iCurrentItem / iItemsPerLine) : iPageLineOffset;
+         k = (g_iCurrentItem < iItemsPerLine * iPageLineOffset) ? (g_iCurrentItem / iItemsPerLine) : iPageLineOffset;
 
-		 j = 35 + j * iItemTextWidth;
-		 k = 54 + k * 18 + iBoxYOffset;
+         j = 35 + j * iItemTextWidth;
+         k = 54 + k * 18 + iBoxYOffset;
 
          PAL_DrawText(PAL_GetWord(rgMagicItem[g_iCurrentItem].wMagic), PAL_XY(j, k), MENUITEM_COLOR_CONFIRMED, FALSE, TRUE, FALSE);
+
+         //
+         // Draw the cursor on the current selected item
+         //
+         PAL_RLEBlitToSurface(PAL_SpriteGetFrame(gpSpriteUI, SPRITENUM_CURSOR), gpScreen, PAL_XY(j + iCursorXOffset, k + 10));
 
          return rgMagicItem[g_iCurrentItem].wMagic;
       }

--- a/ui.h
+++ b/ui.h
@@ -27,9 +27,9 @@
 #define CHUNKNUM_SPRITEUI                  9
 
 #define MENUITEM_COLOR                     0x4F
-#define MENUITEM_COLOR_INACTIVE            0x1C
+#define MENUITEM_COLOR_INACTIVE            0x18
 #define MENUITEM_COLOR_CONFIRMED           0x2C
-#define MENUITEM_COLOR_SELECTED_INACTIVE   0x1F
+#define MENUITEM_COLOR_SELECTED_INACTIVE   0x1C
 #define MENUITEM_COLOR_SELECTED_FIRST      0xF9
 #define MENUITEM_COLOR_SELECTED_TOTALNUM   6
 
@@ -108,6 +108,8 @@
 
 #define SPRITENUM_SLASH                    39
 #define SPRITENUM_ITEMBOX                  70
+#define SPRITENUM_CURSOR_YELLOW_UP         66
+#define SPRITENUM_CURSOR_UP                67
 #define SPRITENUM_CURSOR_YELLOW            68
 #define SPRITENUM_CURSOR                   69
 #define SPRITENUM_PLAYERINFOBOX            18

--- a/uigame.c
+++ b/uigame.c
@@ -727,6 +727,8 @@ PAL_InGameMagicMenu(
          break;
       }
 
+      VIDEO_BackupScreen(gpScreen);
+
       if (gpGlobals->g.rgObject[wMagic].magic.wFlags & kMagicFlagApplyToAll)
       {
          gpGlobals->g.rgObject[wMagic].magic.wScriptOnUse =
@@ -773,13 +775,15 @@ PAL_InGameMagicMenu(
             //
             // Draw the cursor on the selected item
             //
-            rect.x = 70 + 78 * wPlayer;
-            rect.y = 193;
-            rect.w = 9;
+            rect.x = 0;
+            rect.y = 158;
+            rect.w = 320;
             rect.h = 6;
 
-            PAL_RLEBlitToSurface(PAL_SpriteGetFrame(gpSpriteUI, SPRITENUM_CURSOR),
-               gpScreen, PAL_XY(rect.x, rect.y));
+            VIDEO_RestoreScreen(gpScreen);
+
+            PAL_RLEBlitToSurface(PAL_SpriteGetFrame(gpSpriteUI, SPRITENUM_CURSOR_UP),
+               gpScreen, PAL_XY(75 + 78 * wPlayer, rect.y));
 
             VIDEO_UpdateScreen(&rect);
 


### PR DESCRIPTION
**### 测试版本：**
        _DOSBOX Ver 0.72.0.0 中运行仙剑 DOS 版_
        _VMware Workstation Pro Ver17.5.0 中 Windows10 下运行 Pal Windows 95 3.0 补丁 By Yihua Lou。_

**### 测试方法及结果：**
        _对 sdlpal 的仙术菜单、道具菜单和 PlayerInfoBox 菜单与 DOS 版，Win95 版进行了对比，DOS 版与 Win95 版情况一致。_

**### 源项目出现的问题：**
        _平时使用单人回血类法术的 PlayerInfoBox 菜单光标与原生 PAL 不同。_
        _下键也是，在末选项上的时候，再按下键本该跳到首选项，sdlpal 按下也没反应。_

**### 该 PR 的解决方案：**
        _修改字体颜色索引与原生 PAL 一致。_
        _将 PlayerInfoBox 菜单的下光标改为了上光标，并重设了光标的坐标。_

**### 附件：**
![paldos](https://github.com/sdlpal/sdlpal/assets/83107010/a9440149-86b4-47b1-acb7-e529a4311598)
![palwin95](https://github.com/sdlpal/sdlpal/assets/83107010/2ef32277-3308-437e-81da-759fe32a32c5)
![sdlpal-error](https://github.com/sdlpal/sdlpal/assets/83107010/8a4cb111-255a-4a1a-8ac1-b3119c5e7d28)
![sdlpal-fixed](https://github.com/sdlpal/sdlpal/assets/83107010/7f8779b5-c0a4-40e8-a44a-fa6acb7c38af)


- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [x] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
