### PR TITLE
战斗中选择玩家目标时应该显示命令选项，而不是省略

### DIFF
--- a/uibattle.c
+++ b/uibattle.c
@@ -804,6 +804,19 @@ PAL_BattleUIUpdate(
    WORD             wPlayerRole, w;
    static int       s_iFrame = 0;
 
+   struct {
+      int               iSpriteNum;
+      PAL_POS           pos;
+      BATTLEUIACTION    action;
+   } rgItems[] =
+   {
+      {SPRITENUM_BATTLEICON_ATTACK,    PAL_XY(27, 140), kBattleUIActionAttack},
+      {SPRITENUM_BATTLEICON_MAGIC,     PAL_XY(0, 155),  kBattleUIActionMagic},
+      {SPRITENUM_BATTLEICON_COOPMAGIC, PAL_XY(54, 155), kBattleUIActionCoopMagic},
+      {SPRITENUM_BATTLEICON_MISCMENU,  PAL_XY(27, 170), kBattleUIActionMisc}
+   };
+
+
    s_iFrame++;
 
    if (g_Battle.UI.fAutoAttack && !gpGlobals->fAutoBattle)
@@ -1016,18 +1029,6 @@ PAL_BattleUIUpdate(
       // Draw the icons
       //
       {
-         struct {
-            int               iSpriteNum;
-            PAL_POS           pos;
-            BATTLEUIACTION    action;
-         } rgItems[] =
-         {
-            {SPRITENUM_BATTLEICON_ATTACK,    PAL_XY(27, 140), kBattleUIActionAttack},
-            {SPRITENUM_BATTLEICON_MAGIC,     PAL_XY(0, 155),  kBattleUIActionMagic},
-            {SPRITENUM_BATTLEICON_COOPMAGIC, PAL_XY(54, 155), kBattleUIActionCoopMagic},
-            {SPRITENUM_BATTLEICON_MISCMENU,  PAL_XY(27, 170), kBattleUIActionMisc}
-         };
-
          if (g_Battle.UI.MenuState == kBattleMenuMain)
          {
             if (g_InputState.dir == kDirNorth)
@@ -1552,6 +1553,13 @@ PAL_BattleUIUpdate(
          PAL_BattleCommitAction(FALSE);
       }
 #endif
+
+      for (i = 0; i < 4; i++)
+      {
+         PAL_RLEBlitMonoColor(PAL_SpriteGetFrame(gpSpriteUI, rgItems[i].iSpriteNum),
+            gpScreen, rgItems[i].pos, 0, -4);
+      }
+
 
       j = SPRITENUM_BATTLE_ARROW_SELECTEDPLAYER;
       if (s_iFrame & 1)


### PR DESCRIPTION
**### 测试版本：**
        _DOSBOX Ver 0.72.0.0 中运行仙剑 DOS 版_
        _VMware Workstation Pro Ver17.5.0 中 Windows10 下运行 Pal Windows 95 3.0 补丁 By Yihua Lou。_

**### 测试方法及结果：**
        _对 sdlpal 的 战时队员选择菜单 与 DOS 版、Win95 版进行了对比，DOS 版与 Win95 版情况一致。_

**### 源项目出现的问题：**
        _战斗中选择玩家目标时应该同时显示命令选项，sdlpal 未显示。_

**### 该 PR 的解决方案：**
        _使用作用于我方单人的道具或者仙术，选择队员目标时，增加了左边命令选项的显示。_

**### 附件：**
![paldos](https://github.com/sdlpal/sdlpal/assets/83107010/786dc84e-eb62-4614-a82c-5d39f6b7c24d)
![palwin95](https://github.com/sdlpal/sdlpal/assets/83107010/bd85b2d0-f30c-45ae-a8e1-ee49613e9d7f)
![sdlpal-error](https://github.com/sdlpal/sdlpal/assets/83107010/ac7d7dff-24d4-4748-8e46-37bbbd130869)
![sdlpal-fixed](https://github.com/sdlpal/sdlpal/assets/83107010/4a98864d-7ba2-41ed-8054-1dd3fb3e736f)

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [x] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
