### PR TITLE
修复了平时（不在战斗中时）活人可以食用 “傀儡虫” 的bug

### DIFF
--- a/global.c
+++ b/global.c
@@ -2126,7 +2126,7 @@ PAL_RemoveMagic(
    }
 }
 
-VOID
+BOOL
 PAL_SetPlayerStatus(
    WORD         wPlayerRole,
    WORD         wStatusID,
@@ -2151,6 +2151,8 @@ PAL_SetPlayerStatus(
 
 --*/
 {
+   BOOL           fSuccess = TRUE;
+
 #ifndef PAL_CLASSIC
    if (wStatusID == kStatusSlow &&
       gpGlobals->rgPlayerStatus[wPlayerRole][kStatusHaste] > 0)
@@ -2196,10 +2198,16 @@ PAL_SetPlayerStatus(
       //
       // only allow dead players for "puppet" status
       //
-      if (gpGlobals->g.PlayerRoles.rgwHP[wPlayerRole] == 0 &&
-         gpGlobals->rgPlayerStatus[wPlayerRole][wStatusID] < wNumRound)
+      if (gpGlobals->g.PlayerRoles.rgwHP[wPlayerRole] == 0)
       {
-         gpGlobals->rgPlayerStatus[wPlayerRole][wStatusID] = wNumRound;
+         if (gpGlobals->rgPlayerStatus[wPlayerRole][wStatusID] < wNumRound)
+         {
+            gpGlobals->rgPlayerStatus[wPlayerRole][wStatusID] = wNumRound;
+         }
+      }
+      else
+      {
+         fSuccess = FALSE;
       }
       break;
 
@@ -2221,6 +2229,8 @@ PAL_SetPlayerStatus(
       assert(FALSE);
       break;
    }
+
+   return fSuccess;
 }
 
 VOID

--- a/global.h
+++ b/global.h
@@ -722,7 +722,7 @@ PAL_RemoveMagic(
    WORD           wMagic
 );
 
-VOID
+BOOL
 PAL_SetPlayerStatus(
    WORD         wPlayerRole,
    WORD         wStatusID,

--- a/script.c
+++ b/script.c
@@ -1329,7 +1329,10 @@ PAL_InterpretInstruction(
       //
       // Set the status for player
       //
-      PAL_SetPlayerStatus(wEventObjectID, pScript->rgwOperand[0], pScript->rgwOperand[1]);
+      if (!PAL_SetPlayerStatus(wEventObjectID, pScript->rgwOperand[0], pScript->rgwOperand[1]))
+      {
+         g_fScriptSuccess = FALSE;
+      }
       break;
 
    case 0x002E:


### PR DESCRIPTION
**### 测试版本：**
        _DOSBOX Ver 0.72.0.0 中运行仙剑 DOS 版_
        _VMware Workstation Pro Ver17.5.0 中 Windows10 下运行 Pal Windows 95 3.0 补丁 By Yihua Lou。_

**### 测试方法及结果：**
        _对 sdlpal 的平时吃傀儡虫的情况与 DOS 版，Win95 版进行了对比，DOS 版与 Win95 版情况一致。_

**### 源项目出现的问题：**
        _平时活人能吃傀儡虫。_

**### 该 PR 的解决方案：**
        _傀儡虫修复原理与平时吃止血草、金创药、观音符等作用单人的道具差不多，后者以满HP作为使用失败的条件，前者则以HP大于0作为使用失败的条件。_

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [x] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
