### PR TITLE
调整了商店UI

### DIFF
--- a/uigame.c
+++ b/uigame.c
@@ -1504,23 +1504,31 @@ PAL_BuyMenu_OnItemChange(
 --*/
 {
    const SDL_Rect      rect = {20, 8, 300, 175};
-   int                 i, n;
+   int                 i, n, x, y;
    PAL_LARGE BYTE      bufImage[2048];
 
+   //
+   // Prepare item bakcground box pos
+   //
+   x = 40, y = 8;
+
    if( __buymenu_firsttime_render )
-      PAL_RLEBlitToSurfaceWithShadow(PAL_SpriteGetFrame(gpSpriteUI, SPRITENUM_ITEMBOX), gpScreen, PAL_XY(35+6, 8+6), TRUE);
+      PAL_RLEBlitToSurfaceWithShadow(PAL_SpriteGetFrame(gpSpriteUI, SPRITENUM_ITEMBOX), gpScreen, PAL_XY(x + 6, y + 6), TRUE);
    //
    // Draw the picture of current selected item
    //
    PAL_RLEBlitToSurface(PAL_SpriteGetFrame(gpSpriteUI, SPRITENUM_ITEMBOX), gpScreen,
-      PAL_XY(35, 8));
+      PAL_XY(x, y));
+
+   //
+   // Prepare item pos
+   //
+   x = 48, y = 15;
 
    if (PAL_MKFReadChunk(bufImage, 2048,
       gpGlobals->g.rgObject[wCurrentItem].item.wBitmap, gpGlobals->f.fpBALL) > 0)
    {
-      if( __buymenu_firsttime_render )
-         PAL_RLEBlitToSurfaceWithShadow(bufImage, gpScreen, PAL_XY(42+6, 16+6), TRUE);
-      PAL_RLEBlitToSurface(bufImage, gpScreen, PAL_XY(42, 16));
+      PAL_RLEBlitToSurface(bufImage, gpScreen, PAL_XY(x, y));
    }
 
    //
@@ -1541,25 +1549,35 @@ PAL_BuyMenu_OnItemChange(
       }
    }
 
+   //
+   // Prepare inventory quantities pos
+   //
+   x = 20, y = 100;
+
    if( __buymenu_firsttime_render )
-      PAL_CreateSingleLineBoxWithShadow(PAL_XY(20, 105), 5, FALSE, 6);
+      PAL_CreateSingleLineBoxWithShadow(PAL_XY(x, y), 5, FALSE, 6);
    else
    //
    // Draw the amount of this item in the inventory
    //
-   PAL_CreateSingleLineBoxWithShadow(PAL_XY(20, 105), 5, FALSE, 0);
-   PAL_DrawText(PAL_GetWord(BUYMENU_LABEL_CURRENT), PAL_XY(30, 115), 0, FALSE, FALSE, FALSE);
-   PAL_DrawNumber(n, 6, PAL_XY(69, 119), kNumColorYellow, kNumAlignRight);
+   PAL_CreateSingleLineBoxWithShadow(PAL_XY(x, y), 5, FALSE, 0);
+   PAL_DrawText(PAL_GetWord(BUYMENU_LABEL_CURRENT), PAL_XY(x + 10, y + 10), 0, FALSE, FALSE, FALSE);
+   PAL_DrawNumber(n, 6, PAL_XY(x + 49, y + 15), kNumColorYellow, kNumAlignRight);
+
+   //
+   // Prepare inventory quantities pos
+   //
+   x = 20, y = 141;
 
    if( __buymenu_firsttime_render )
-      PAL_CreateSingleLineBoxWithShadow(PAL_XY(20, 145), 5, FALSE, 6);
+      PAL_CreateSingleLineBoxWithShadow(PAL_XY(x, y), 5, FALSE, 6);
    else
    //
    // Draw the cash amount
    //
-   PAL_CreateSingleLineBoxWithShadow(PAL_XY(20, 145), 5, FALSE, 0);
-   PAL_DrawText(PAL_GetWord(CASH_LABEL), PAL_XY(30, 155), 0, FALSE, FALSE, FALSE);
-   PAL_DrawNumber(gpGlobals->dwCash, 6, PAL_XY(69, 159), kNumColorYellow, kNumAlignRight);
+   PAL_CreateSingleLineBoxWithShadow(PAL_XY(x, y), 5, FALSE, 0);
+   PAL_DrawText(PAL_GetWord(CASH_LABEL), PAL_XY(x + 10, y + 10), 0, FALSE, FALSE, FALSE);
+   PAL_DrawNumber(gpGlobals->dwCash, 6, PAL_XY(x + 49, y + 15), kNumColorYellow, kNumAlignRight);
 
    VIDEO_UpdateScreen(&rect);
    
@@ -1592,7 +1610,7 @@ PAL_BuyMenu(
    //
    // create the menu items
    //
-   y = 22;
+   y = 21;
 
    for (i = 0; i < MAX_STORE_ITEM; i++)
    {
@@ -1612,7 +1630,7 @@ PAL_BuyMenu(
    //
    // Draw the box
    //
-   PAL_CreateBox(PAL_XY(125, 8), 8, 8, 1, FALSE);
+   PAL_CreateBox(PAL_XY(122, 8), 8, 8, 1, FALSE);
 
    //
    // Draw the number of prices
@@ -1620,7 +1638,7 @@ PAL_BuyMenu(
    for (y = 0; y < i; y++)
    {
       w = gpGlobals->g.rgObject[rgMenuItem[y].wValue].item.wPrice;
-      PAL_DrawNumber(w, 6, PAL_XY(235, 25 + y * 18), kNumColorCyan, kNumAlignRight);
+      PAL_DrawNumber(w, 6, PAL_XY(238, 26 + y * 18), kNumColorYellow, kNumAlignRight);
    }
 
    w = 0;


### PR DESCRIPTION
**### 测试版本：**
        _DOSBOX Ver 0.72.0.0 中运行仙剑 DOS 版_
        _VMware Workstation Pro Ver17.5.0 中 Windows10 下运行 Pal Windows 95 3.0 补丁 By Yihua Lou。_

**### 测试方法及结果：**
        _对 sdlpal 的商店菜单与 DOS 版，Win95 版进行了抓图对比，DOS 版与 Win95 版UI布局一致。_

**### 源项目出现的问题：**
        _商店UI与原生 PAL 不一致。_

**### 该 PR 的解决方案：**
        _删除了店铺刚打开的时候会绘制道具图像的阴影的效果。_
        _使用 Photoshop 对三者抓的 320*200 大小的图进行了像素级的坐标测量，现已将商店UI布局调整至与原生 PAL 一致。_

**### 附件：**
![paldos](https://github.com/sdlpal/sdlpal/assets/83107010/d0a3e46a-1170-4c1c-aa78-c76205bede40)
![palwin95](https://github.com/sdlpal/sdlpal/assets/83107010/5abbf2d6-f75f-4c5a-b3fa-9c85ea2ff71d)
![sdlpal-error](https://github.com/sdlpal/sdlpal/assets/83107010/e5407b48-aaf9-4d63-aaf5-90534cecea24)
![sdlpal-fixed](https://github.com/sdlpal/sdlpal/assets/83107010/a2e22263-a1ce-4198-8a4f-c38345a5d7d0)

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [x] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
