### PR TITLE
fixed: When the inventory menu is empty.

### DIFF
--- a/itemmenu.c
+++ b/itemmenu.c
@@ -48,7 +48,6 @@ PAL_ItemSelectMenuUpdate(
    WORD               wObject, wScript;
    BYTE               bColor;
    static BYTE        bufImage[2048];
-   static WORD        wPrevImageIndex = 0xFFFF;
    const int          iItemsPerLine = 32 / gConfig.dwWordLength;
    const int          iItemTextWidth = 8 * gConfig.dwWordLength + 20;
    const int          iLinesPerPage = 7 - gConfig.ScreenLayout.ExtraItemDescLines;
@@ -56,6 +55,7 @@ PAL_ItemSelectMenuUpdate(
    const int          iAmountXOffset = gConfig.dwWordLength * 8 + 1;
    const int          iPageLineOffset = (iLinesPerPage + 1) / 2;
    const int          iPictureYOffset = (gConfig.ScreenLayout.ExtraItemDescLines > 1) ? (gConfig.ScreenLayout.ExtraItemDescLines - 1) * 16 : 0;
+   PAL_POS            cursorPos = PAL_XY(15 + iCursorXOffset, 22);;
 
    //
    // Process input
@@ -125,6 +125,8 @@ PAL_ItemSelectMenuUpdate(
       i = 0;
    }
 
+   const int xBase = 0, yBase = 140;
+
    for (j = 0; j < iLinesPerPage; j++)
    {
       for (k = 0; k < iItemsPerLine; k++)
@@ -182,58 +184,46 @@ PAL_ItemSelectMenuUpdate(
          //
          // Draw the text
          //
-		 PAL_DrawText(PAL_GetWord(wObject), PAL_XY(15 + k * iItemTextWidth, 12 + j * 18), bColor, TRUE, FALSE, FALSE);
+         PAL_DrawText(PAL_GetWord(wObject), PAL_XY(15 + k * iItemTextWidth, 12 + j * 18), bColor, TRUE, FALSE, FALSE);
 
-         //
-         // Draw the cursor on the current selected item
-         //
          if (i == gpGlobals->iCurInvMenuItem)
          {
-            PAL_RLEBlitToSurface(PAL_SpriteGetFrame(gpSpriteUI, SPRITENUM_CURSOR),
-               gpScreen, PAL_XY(15 + iCursorXOffset + k * iItemTextWidth, 22 + j * 18));
+            cursorPos = PAL_XY(15 + iCursorXOffset + k * iItemTextWidth, 22 + j * 18);
+
+            //
+            // Draw the picture of current selected item
+            //
+            PAL_RLEBlitToSurfaceWithShadow(PAL_SpriteGetFrame(gpSpriteUI, SPRITENUM_ITEMBOX), gpScreen,
+               PAL_XY(xBase + 5, yBase + 5 - iPictureYOffset), TRUE);
+            PAL_RLEBlitToSurface(PAL_SpriteGetFrame(gpSpriteUI, SPRITENUM_ITEMBOX), gpScreen,
+               PAL_XY(xBase, yBase - iPictureYOffset));
+
+            if (PAL_MKFReadChunk(bufImage, 2048,
+               gpGlobals->g.rgObject[wObject].item.wBitmap, gpGlobals->f.fpBALL) > 0)
+            {
+               PAL_RLEBlitToSurface(bufImage, gpScreen, PAL_XY(xBase + 8, yBase + 7 - iPictureYOffset));
+            }
          }
 
          //
          // Draw the amount of this item
          //
-		 if ((SHORT)gpGlobals->rgInventory[i].nAmount - (SHORT)gpGlobals->rgInventory[i].nAmountInUse > 1)
-		 {
+         if ((SHORT)gpGlobals->rgInventory[i].nAmount - (SHORT)gpGlobals->rgInventory[i].nAmountInUse > 1)
+         {
             PAL_DrawNumber(gpGlobals->rgInventory[i].nAmount - gpGlobals->rgInventory[i].nAmountInUse,
                2, PAL_XY(15 + iAmountXOffset + k * iItemTextWidth, 17 + j * 18), kNumColorCyan, kNumAlignRight);
-		 }
+         }
 
          i++;
       }
    }
 
-   int xBase = 0, yBase = 140;
    //
-   // Draw the picture of current selected item
+   // Draw the cursor on the current selected item
    //
-   PAL_RLEBlitToSurfaceWithShadow(PAL_SpriteGetFrame(gpSpriteUI, SPRITENUM_ITEMBOX), gpScreen,
-      PAL_XY(xBase+5, yBase+5 - iPictureYOffset),TRUE);
-   PAL_RLEBlitToSurface(PAL_SpriteGetFrame(gpSpriteUI, SPRITENUM_ITEMBOX), gpScreen,
-      PAL_XY(xBase, yBase - iPictureYOffset));
+   PAL_RLEBlitToSurface(PAL_SpriteGetFrame(gpSpriteUI, SPRITENUM_CURSOR), gpScreen, cursorPos);
 
    wObject = gpGlobals->rgInventory[gpGlobals->iCurInvMenuItem].wItem;
-
-   if (gpGlobals->g.rgObject[wObject].item.wBitmap != wPrevImageIndex)
-   {
-      if (PAL_MKFReadChunk(bufImage, 2048,
-         gpGlobals->g.rgObject[wObject].item.wBitmap, gpGlobals->f.fpBALL) > 0)
-      {
-         wPrevImageIndex = gpGlobals->g.rgObject[wObject].item.wBitmap;
-      }
-      else
-      {
-         wPrevImageIndex = 0xFFFF;
-      }
-   }
-
-   if (wPrevImageIndex != 0xFFFF)
-   {
-      PAL_RLEBlitToSurface(bufImage, gpScreen, PAL_XY(xBase+8, yBase+7 - iPictureYOffset));
-   }
 
    //
    // Draw the description of the selected item

--- a/uigame.c
+++ b/uigame.c
@@ -1709,23 +1709,27 @@ PAL_SellMenu_OnItemChange(
 
 --*/
 {
+   WORD x = 100, y = 150;
+
    //
    // Draw the cash amount
    //
-   PAL_CreateSingleLineBoxWithShadow(PAL_XY(100, 150), 5, FALSE, 0);
-   PAL_DrawText(PAL_GetWord(CASH_LABEL), PAL_XY(110, 160), 0, FALSE, FALSE, FALSE);
-   PAL_DrawNumber(gpGlobals->dwCash, 6, PAL_XY(149, 164), kNumColorYellow, kNumAlignRight);
+   PAL_CreateSingleLineBoxWithShadow(PAL_XY(x, y), 5, FALSE, 0);
+   PAL_DrawText(PAL_GetWord(CASH_LABEL), PAL_XY(x + 10, y + 10), 0, FALSE, FALSE, FALSE);
+   PAL_DrawNumber(gpGlobals->dwCash, 6, PAL_XY(x + 48, y + 15), kNumColorYellow, kNumAlignRight);
+
+   x += 124;
 
    //
    // Draw the price
    //
-   PAL_CreateSingleLineBoxWithShadow(PAL_XY(220, 150), 5, FALSE, 0);
+   PAL_CreateSingleLineBoxWithShadow(PAL_XY(x, y), 5, FALSE, 0);
 
    if (gpGlobals->g.rgObject[wCurrentItem].item.wFlags & kItemFlagSellable)
    {
-      PAL_DrawText(PAL_GetWord(SELLMENU_LABEL_PRICE), PAL_XY(230, 160), 0, FALSE, FALSE, FALSE);
+      PAL_DrawText(PAL_GetWord(SELLMENU_LABEL_PRICE), PAL_XY(x + 10, y + 10), 0, FALSE, FALSE, FALSE);
       PAL_DrawNumber(gpGlobals->g.rgObject[wCurrentItem].item.wPrice / 2, 6,
-         PAL_XY(269, 164), kNumColorYellow, kNumAlignRight);
+         PAL_XY(x + 48, y + 15), kNumColorYellow, kNumAlignRight);
    }
 }
 


### PR DESCRIPTION
**### 测试版本：**
        _DOSBOX Ver 0.72.0.0 中运行仙剑 DOS 版_
        _VMware Workstation Pro Ver17.5.0 中 Windows10 下运行 Pal Windows 95 3.0 补丁 By Yihua Lou。_

**### 测试方法及结果：**
        _对 sdlpal 的 使用/装备菜单、当铺菜单 与 DOS 版，Win95 版进行了对比，并进行了抓图和使用 Photoshop 进行了测量坐标，但sdlpal只实现了 Win95 版的当铺UI。_

**### 源项目出现的问题：**
        _当铺的线性框坐标与原生PAL不一致。_
        _当铺、使用/装备的菜单没有任何项目时，左下角会展示一个空的道具图像框。_

**### 该 PR 的解决方案：**
        _调整了当铺的现金框、售价框的坐标。_
        _将渲染逻辑改成绘制醒目文字光标的同时绘制道具的图像框，菜单中的项目绘制完毕，最后绘制三角光标。_

**### 附件：**
![paldos](https://github.com/sdlpal/sdlpal/assets/83107010/319dc44f-c3d5-4e27-ac9f-0da9c1bc8994)
![palwin95](https://github.com/sdlpal/sdlpal/assets/83107010/147a65bd-5bd6-45d3-a49b-1fb9aa98e9cd)
![sdlpal-error](https://github.com/sdlpal/sdlpal/assets/83107010/f753fab1-ae64-48dd-9879-7541b76309c5)
![sdlpal-fixed](https://github.com/sdlpal/sdlpal/assets/83107010/9c61458c-8bcc-411f-903d-70dabbbf61f9)

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [x] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
