### PR TITLE
fixed Multiple bugs.

### DIFF
--- a/global.c
+++ b/global.c
@@ -1017,6 +1017,49 @@ PAL_CountItem(
 }
 
 BOOL
+PAL_GetItemIndexToInventory(
+   WORD          wObjectID,
+   INT          *index
+)
+/*++
+  Purpose:
+
+    Search for the specified item in the inventory.
+
+  Parameters:
+
+    [IN]  wObjectID - object number of the item.
+
+    [IN]  index - use a pointer to receive the retrieved inventory index.
+
+  Return value:
+
+    TRUE if found it, FALSE if not found it.
+
+--*/
+{
+   BOOL         fFound = FALSE;
+
+   *index = 0;
+
+   while (*index < MAX_INVENTORY)
+   {
+      if (gpGlobals->rgInventory[*index].wItem == wObjectID)
+      {
+         fFound = TRUE;
+         break;
+      }
+      else if (gpGlobals->rgInventory[*index].wItem == 0)
+      {
+         break;
+      }
+      (*index)++;
+   }
+
+   return fFound;
+}
+
+BOOL
 PAL_AddItemToInventory(
    WORD          wObjectID,
    INT           iNum
@@ -1057,19 +1100,7 @@ PAL_AddItemToInventory(
    //
    // Search for the specified item in the inventory
    //
-   while (index < MAX_INVENTORY)
-   {
-      if (gpGlobals->rgInventory[index].wItem == wObjectID)
-      {
-         fFound = TRUE;
-         break;
-      }
-      else if (gpGlobals->rgInventory[index].wItem == 0)
-      {
-         break;
-      }
-      index++;
-   }
+   fFound = PAL_GetItemIndexToInventory(wObjectID, &index);
 
    if (iNum > 0)
    {

--- a/global.h
+++ b/global.h
@@ -596,6 +596,12 @@ PAL_CountItem(
 );
 
 BOOL
+PAL_GetItemIndexToInventory(
+   WORD          wObjectID,
+   INT* index
+);
+
+BOOL
 PAL_AddItemToInventory(
    WORD          wObjectID,
    INT           iNum

--- a/script.c
+++ b/script.c
@@ -769,11 +769,28 @@ PAL_InterpretInstruction(
          w = gpGlobals->g.PlayerRoles.rgwEquipment[i][wEventObjectID];
          gpGlobals->g.PlayerRoles.rgwEquipment[i][wEventObjectID] = pScript->rgwOperand[1];
 
-         PAL_AddItemToInventory(pScript->rgwOperand[1], -1);
-
-         if (w != 0)
+         if (PAL_GetItemIndexToInventory(pScript->rgwOperand[1], &i)
+            && i < MAX_INVENTORY
+            && gpGlobals->rgInventory[i].nAmount == 1
+            && w != 0
+            && !PAL_GetItemIndexToInventory(w, &j))
          {
-            PAL_AddItemToInventory(w, 1);
+            //
+            // When the number of items you want to wear is 1 
+            // and the number of items you are wearing is also 1, 
+            // replace them directly, instead of removing items 
+            // and adding them at the end of the item menu
+            //
+            gpGlobals->rgInventory[i].wItem = w;
+         }
+         else
+         {
+            PAL_AddItemToInventory(pScript->rgwOperand[1], -1);
+
+            if (w != 0)
+            {
+               PAL_AddItemToInventory(w, 1);
+            }
          }
 
          gpGlobals->wLastUnequippedItem = w;

--- a/text.c
+++ b/text.c
@@ -1139,14 +1139,22 @@ PAL_DrawTextUnescape(
       //
       // Draw the character
       //
-	  int char_width = fUse8x8Font ? 8 : PAL_CharWidth(*lpszText);
+      int char_width = fUse8x8Font ? 8 : PAL_CharWidth(*lpszText);
 
       if (fShadow)
       {
-		  PAL_DrawCharOnSurface(*lpszText, gpScreen, PAL_XY(rect.x + 1, rect.y + 1), 0, fUse8x8Font);
+         //
+         // Note: In the original PAL DOS version, 
+         // the text has triple shadows, while Win95 only has one layer. 
+         // It is suspected that there is a bug in the original Win95 version, 
+         // so sdlpal chose to use triple shadows for both.
+         //
+         PAL_DrawCharOnSurface(*lpszText, gpScreen, PAL_XY(rect.x + 1, rect.y), 0, fUse8x8Font);
+         PAL_DrawCharOnSurface(*lpszText, gpScreen, PAL_XY(rect.x, rect.y + 1), 0, fUse8x8Font);
+         PAL_DrawCharOnSurface(*lpszText, gpScreen, PAL_XY(rect.x + 1, rect.y + 1), 0, fUse8x8Font);
       }
-	  PAL_DrawCharOnSurface(*lpszText++, gpScreen, PAL_XY(rect.x, rect.y), bColor, fUse8x8Font);
-	  rect.x += char_width; urect.w += char_width;
+      PAL_DrawCharOnSurface(*lpszText++, gpScreen, PAL_XY(rect.x, rect.y), bColor, fUse8x8Font);
+      rect.x += char_width; urect.w += char_width;
    }
 
    //

--- a/ui.h
+++ b/ui.h
@@ -40,7 +40,7 @@
 
 #define MENUITEM_COLOR_EQUIPPEDITEM        0xC8
 
-#define DESCTEXT_COLOR                     0x2E
+#define DESCTEXT_COLOR                     0x3C
 
 #define MAINMENU_BACKGROUND_FBPNUM         (gConfig.fIsWIN95 ? 2 :60)
 


### PR DESCRIPTION
**### 测试版本：**
        _DOSBOX Ver 0.72.0.0 中运行仙剑 DOS 版_
        _VMware Workstation Pro Ver17.5.0 中 Windows10 下运行 Pal Windows 95 3.0 补丁 By Yihua Lou。_

**### 测试方法及结果：**
        _对 sdlpal 的装备的装卸与 DOS 版，Win95 版进行了对比，DOS 版与 Win95 版情况一致。_

**### 源项目出现的问题：**
        _当你想要佩戴的物品数量为1，而你正在佩戴的物品在背包中不存在更多时，应该直接用换下来的装备直接替换掉刚才装备上的道具在道具菜单的位置，而不是删除掉再在物品菜单的末尾添加。_
        _sdlpal中道具和魔法描述文本的字体颜色与原生 Win95 版不同。_
        _DOS版中文字是有三层阴影的，而sdlpal只有一层。_

**### 该 PR 的解决方案：**
        _详见 review。_

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [x] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
