### PR TITLE
fixbug: after selecting an item in the prop menu, it should be the triangular cursor pressing down on the flashing text, rather than the text pressing down on the triangular cursor

### DIFF
--- a/itemmenu.c
+++ b/itemmenu.c
@@ -292,10 +292,15 @@ PAL_ItemSelectMenuUpdate(
       {
          if (gpGlobals->rgInventory[gpGlobals->iCurInvMenuItem].nAmount > 0)
          {
-			 j = (gpGlobals->iCurInvMenuItem < iItemsPerLine * iPageLineOffset) ? (gpGlobals->iCurInvMenuItem / iItemsPerLine) : iPageLineOffset;
-			k = gpGlobals->iCurInvMenuItem % iItemsPerLine;
+            j = (gpGlobals->iCurInvMenuItem < iItemsPerLine * iPageLineOffset) ? (gpGlobals->iCurInvMenuItem / iItemsPerLine) : iPageLineOffset;
+            k = gpGlobals->iCurInvMenuItem % iItemsPerLine;
 
             PAL_DrawText(PAL_GetWord(wObject), PAL_XY(15 + k * iItemTextWidth, 12 + j * 18), MENUITEM_COLOR_CONFIRMED, FALSE, FALSE, FALSE);
+
+            //
+            // Draw the cursor on the current selected item
+            //
+            PAL_RLEBlitToSurface(PAL_SpriteGetFrame(gpSpriteUI, SPRITENUM_CURSOR), gpScreen, cursorPos);
          }
 
          return wObject;


### PR DESCRIPTION

- [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [ ] Have you written new tests for your changes?

- [ ] Have you successfully run it with your changes locally?

- [ ] Have you tested on following platforms?
  - [ ] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [ ] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
