### PR TITLE
修复战斗中自动选择敌方目标的算法

### DIFF
--- a/fight.c
+++ b/fight.c
@@ -121,7 +121,7 @@ PAL_BattleSelectAutoTargetFrom(
       {
          return i;
       }
-      i = ( i + 1 ) % MAX_ENEMIES_IN_TEAM;
+      i = ( i + 1 ) % (g_Battle.wMaxEnemyIndex + 1);
    }
 
    return -1;


### PR DESCRIPTION
**### 测试版本：**
        _DOSBOX Ver 0.72.0.0 中运行仙剑 DOS 版_
        _VMware Workstation Pro Ver17.5.0 中 Windows10 下运行 Pal Windows 95 3.0 补丁 By Yihua Lou。_

**### 测试方法及结果：**
        _对 sdlpal 的所以会影响到快捷键 R 的动作与 DOS 版，Win95 版进行了对比，DOS 版与 Win95 版情况一致。_

**### 源项目出现的问题：**
        _sdlpal 在战斗中执行一回合的行动后，自动记录上次的命令和目标，但再次按 R 键重复上次行动，若行动是攻击单人的，且要攻击的敌人已经死亡或者下一战时不存在就会自动选择目标，到这里为止逻辑是对的，但自动选择目标以后会把上次手动选择的目标覆盖掉，导致之后的重复命令不再是攻击最开始玩家手动选择的目标了。_
        _一般情况，队员行动时实际目标不存在会向后查找。但按快捷键 R 键时，会查找两次，先向前查找一次，再向后查找一次。_

**### 源项目问题的重现方式：**
        _最典型的三连战：_
        _**第一战      1.苗人拳/2.胖喵/3.苗人拳**_
        _四木剑杀掉 1.胖喵_
        _木剑炎咒R杀掉 **2.苗人拳**    （此时 sdlpal 目标记忆为 1 号敌人，pal相同）_
        _RR杀掉 **0.苗人拳**    （此时 sdlpal 目标记忆还是 2 号敌人，pal相同）_
        _**第二战      1.林月如**_
        _RR    （此时 sdlpal 目标记忆被替换为 1 号敌人，pal则还是 2 号敌人）_
        _**第三战      1.刀手/2.罗汉退**_
        _R      （此时 sdlpal 会使用木剑炎咒攻击 **1.刀手**。pal会攻击三号敌人，但三号敌人不存在，pal向前查找了敌人，会自动攻击二号敌人 **2.罗汉退**）_

**### 该 PR 的解决方案：**
        _为 sdlpal 添加了向前查找目标的功能。_
        _将 sdlpal 快捷键 R 的自动目标改为向前查找，再向后查找一次。_

**### 该 PR 的隐患：**
        _未知，目前已经解决了 sdlpal 快捷键 R 自动选择目标的问题，可能需要更多测试。_

**### 附件：**
        _具体问题详见：**https://www.bilibili.com/video/BV1pA4m1G7id/**_

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [x] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
