### PR TITLE
fixbug: index of the current selected item of the sell menu.

### DIFF
--- a/game.c
+++ b/game.c
@@ -46,6 +46,8 @@ PAL_GameMain(
    // Show the opening menu.
    //
    gpGlobals->bCurrentSaveSlot = (BYTE)PAL_OpeningMenu();
+   gpGlobals->iCurInvMenuItem = 0;
+   gpGlobals->iCurSellMenuItem = 0;
    gpGlobals->fInMainGame = TRUE;
 
    //

--- a/global.c
+++ b/global.c
@@ -945,7 +945,6 @@ PAL_InitGameData(
       PAL_LoadDefaultGame();
    }
 
-   gpGlobals->iCurInvMenuItem = 0;
    gpGlobals->fInBattle = FALSE;
 
    memset(gpGlobals->rgPlayerStatus, 0, sizeof(gpGlobals->rgPlayerStatus));
@@ -1160,7 +1159,10 @@ PAL_AddItemToInventory(
          /// Need process last item
          //
          if(gpGlobals->rgInventory[index].nAmount == 0 && index == gpGlobals->iCurInvMenuItem && index+1 < MAX_INVENTORY && gpGlobals->rgInventory[index+1].nAmount <= 0)
+         {
             gpGlobals->iCurInvMenuItem --;
+            gpGlobals->iCurSellMenuItem--;
+         }
          return TRUE;
       }
 

--- a/global.h
+++ b/global.h
@@ -506,6 +506,7 @@ typedef struct tagGLOBALVARS
    int              iCurMainMenuItem;    // current main menu item number
    int              iCurSystemMenuItem;  // current system menu item number
    int              iCurInvMenuItem;     // current inventory menu item number
+   int              iCurSellMenuItem;    // current sell menu item number
    int              iCurPlayingRNG;      // current playing RNG animation
    BYTE             bCurrentSaveSlot;    // current save slot (1-5)
    BOOL             fInMainGame;         // TRUE if in main game

--- a/itemmenu.h
+++ b/itemmenu.h
@@ -29,7 +29,7 @@ PAL_C_LINKAGE_BEGIN
 
 WORD
 PAL_ItemSelectMenuUpdate(
-   VOID
+   BOOL                      fIsInvMenu
 );
 
 VOID

--- a/uibattle.c
+++ b/uibattle.c
@@ -641,7 +641,7 @@ PAL_BattleUIUseItem(
 {
    WORD       wSelectedItem;
 
-   wSelectedItem = PAL_ItemSelectMenuUpdate();
+   wSelectedItem = PAL_ItemSelectMenuUpdate(TRUE);
 
    if (wSelectedItem != 0xFFFF)
    {
@@ -690,7 +690,7 @@ PAL_BattleUIThrowItem(
 
 --*/
 {
-   WORD wSelectedItem = PAL_ItemSelectMenuUpdate();
+   WORD wSelectedItem = PAL_ItemSelectMenuUpdate(TRUE);
 
    if (wSelectedItem != 0xFFFF)
    {


### PR DESCRIPTION
**### 测试版本：**
        _DOSBOX-X[v2023.10.06] 中运行仙剑 DOS 版_
        _DOSBOX-X[v2023.10.06] 中 Windows98 下挂载 Pal Windows 95 简体版 Setup 镜像 运行 Pal Windows 95 原版_

**### 该 PR 的解决方案：**
        _1. DOS version: where is the cursor after opening the sell menu, and where will it remain after reopening,_
        _2. version 98: every time the pawnshop is opened, the cursor will reset to the position of the first item._
        _3. Does not share the cursor with the item inventory._
        _4. reading save file will not reset the cursor position of sell menu and item inventory to the position of the first item._


- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [x] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
