### PR TITLE
fixbug: in the auto script, when the player walks automatically, QuMoXiang time should pass. thinks @palxex for verifying.

### DIFF
--- a/play.c
+++ b/play.c
@@ -241,6 +241,11 @@ PAL_GameUpdate(
       }
    }
 
+   if (--gpGlobals->wChasespeedChangeCycles == 0)
+   {
+      gpGlobals->wChaseRange = 1;
+   }
+
    gpGlobals->dwFrameNum++;
 }
 
@@ -572,11 +577,6 @@ PAL_StartFrame(
       // Quit Game
       //
       PAL_QuitGame();
-   }
-
-   if (--gpGlobals->wChasespeedChangeCycles == 0)
-   {
-      gpGlobals->wChaseRange = 1;
    }
 }
 


### PR DESCRIPTION

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
