### PR TITLE
Fix the issue where the animation is inconsistent with the original version when players use physical attacks to attack all enemies

### DIFF
--- a/battle.h
+++ b/battle.h
@@ -110,6 +110,7 @@ typedef struct tagBATTLEPLAYER
    BATTLEACTION       action;               // action to perform
    BATTLEACTION       prevAction;           // action of the previous turn
    BOOL               fDefending;           // TRUE if player is defending
+   BOOL               fSecondAttack;           // True for the first full attack, false for the second full attack
    WORD               wPrevHP;              // HP value prior to action
    WORD               wPrevMP;              // MP value prior to action
 #ifndef PAL_CLASSIC


### PR DESCRIPTION
Fixed an issue where the character's animation was inconsistent with the original when the weapon equipped by the character attacked all enemies and could be re-attacked

1. 全体+两次，我方攻击时人物的坐标不应该跑到敌人面前。
2. 全体的情况下，武器特效要对所有在场的敌人播放，而不是固定目标。

- [√] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [√ ] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [√] Have you written new tests for your changes?

- [√] Have you successfully run it with your changes locally?

- [√] Have you tested on following platforms?
  - [√] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [√] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
