### PR TITLE
fix fSecondAttack Bug

### DIFF
--- a/battle.h
+++ b/battle.h
@@ -110,7 +110,7 @@ typedef struct tagBATTLEPLAYER
    BATTLEACTION       action;               // action to perform
    BATTLEACTION       prevAction;           // action of the previous turn
    BOOL               fDefending;           // TRUE if player is defending
-   BOOL               fSecondAttack;           // True for the first full attack, false for the second full attack
+   BOOL               fSecondAttack;           // FALSE for the first full attack, TRUE for the second full attack
    WORD               wPrevHP;              // HP value prior to action
    WORD               wPrevMP;              // MP value prior to action
 #ifndef PAL_CLASSIC

--- a/fight.c
+++ b/fight.c
@@ -3754,6 +3754,7 @@ PAL_BattlePlayerPerformAction(
          }
       }
 
+      g_Battle.rgPlayer[wPlayerIndex].fSecondAttack = FALSE;
       PAL_BattleUpdateFighters();
       PAL_BattleMakeScene();
       PAL_BattleDelay(3, 0, TRUE);


### PR DESCRIPTION
Fixed player's failure to reset next attack coordinates after attacking all enemies twice

- [√ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [√ ] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [√ ] Have you written new tests for your changes?

- [√ ] Have you successfully run it with your changes locally?

- [√ ] Have you tested on following platforms?
  - [√ ] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [√ ] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
