### PR TITLE
fix game open menu logic

### DIFF
--- a/uigame.c
+++ b/uigame.c
@@ -147,7 +147,7 @@ PAL_OpeningMenu(
          {
             break;
          }
-         wDefaultItem = 1;
+         wDefaultItem = 0;
       }
    }
 


### PR DESCRIPTION
Returning to the open menu cursor from loading game should default to start the game

- [√ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [√ ] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [√ ] Have you written new tests for your changes?

- [√ ] Have you successfully run it with your changes locally?

- [√ ] Have you tested on following platforms?
  - [ ] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [√ ] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
