### PR TITLE
fix Physical Attack damage to all enemies

### DIFF
--- a/fight.c
+++ b/fight.c
@@ -3706,8 +3706,7 @@ PAL_BattlePlayerPerformAction(
                def += (g_Battle.rgEnemy[index[i]].e.wLevel + 6) * 4;
                res = g_Battle.rgEnemy[index[i]].e.wPhysicalResistance;
 
-               sDamage = PAL_CalcPhysicalAttackDamage(str, def, res);
-               sDamage += RandomLong(1, 2);
+               FLOAT sDamage = PAL_CalcPhysicalAttackDamage(str, def, res);
 
                if (fCritical)
                {
@@ -3719,8 +3718,6 @@ PAL_BattlePlayerPerformAction(
 
                sDamage /= division;
 
-               sDamage = (SHORT)(sDamage * RandomFloat(1, 1.125));
-
                if (sDamage <= 0)
                {
                   sDamage = 1;
@@ -3728,11 +3725,8 @@ PAL_BattlePlayerPerformAction(
 
                g_Battle.rgEnemy[index[i]].e.wHealth -= sDamage;
 
-               division++;
-               if (division > 3)
-               {
-                  division = 3;
-               }
+               if (g_Battle.rgEnemy[index[i]].wObjectID != 0)
+                    division *= 2;
             }
 
             if (t > 0)


### PR DESCRIPTION
The next enemy should take half the damage taken by the previous enemy
对多个敌人进行全体物理攻击的时候，敌人受到的伤害应该依次减半，例：100-50-25-12-6
- [√ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [√ ] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [ √] Have you written new tests for your changes?

- [√ ] Have you successfully run it with your changes locally?

- [ √] Have you tested on following platforms?
  - [√ ] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [ ] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
