### PR TITLE
fix: incorrect countdown pause of enemy alert range change.

### DIFF
--- a/play.c
+++ b/play.c
@@ -241,6 +241,11 @@ PAL_GameUpdate(
       }
    }
 
+   if (--gpGlobals->wChasespeedChangeCycles == 0)
+   {
+      gpGlobals->wChaseRange = 1;
+   }
+
    gpGlobals->dwFrameNum++;
 }
 
@@ -572,11 +577,6 @@ PAL_StartFrame(
       // Quit Game
       //
       PAL_QuitGame();
-   }
-
-   if (--gpGlobals->wChasespeedChangeCycles == 0)
-   {
-      gpGlobals->wChaseRange = 1;
    }
 }
 


### PR DESCRIPTION

In certain cases, such as standing on a moving platform, the player team moves automatically in the overridden game loop within the trigger script.

In such cases, if an item that temporarily changes enemy alert range is in effect, the countdown for the effect now continues, instead of incorrectly pausing.

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
