### PR TITLE
优化PC端的方向键行走事件

### DIFF
--- a/input.c
+++ b/input.c
@@ -90,6 +90,35 @@ static const int g_KeyMap[][2] = {
    { SDLK_s,         kKeyStatus }
 };
 
+static INT
+PAL_GetCurrDirection(
+   VOID
+)
+/*++
+  Purpose:
+
+    Get the current walking direction.
+
+  Parameters:
+
+    None.
+
+  Return value:
+
+    None.
+
+--*/
+{
+   INT i, iCurrDir = kDirSouth;
+
+   for (i = 1; i < sizeof(g_InputState.dwKeyOrder) / sizeof(g_InputState.dwKeyOrder[0]); i++)
+      if (g_InputState.dwKeyOrder[iCurrDir] < g_InputState.dwKeyOrder[i]) iCurrDir = i;
+
+   if (!g_InputState.dwKeyOrder[iCurrDir]) iCurrDir = kDirUnknown;
+
+   return iCurrDir;
+}
+
 static VOID
 PAL_KeyDown(
    INT         key,
@@ -110,48 +139,36 @@ PAL_KeyDown(
 
 --*/
 {
-   switch (key)
+   INT iCurrDir = kDirUnknown;
+
+   if (!fRepeat)
    {
-   case kKeyUp:
-      if (g_InputState.dir != kDirNorth && !fRepeat)
+      if (key & kKeyDown)
       {
-         g_InputState.prevdir = (gpGlobals->fInBattle ? kDirUnknown : g_InputState.dir);
-         g_InputState.dir = kDirNorth;
+         iCurrDir = kDirSouth;
       }
-      g_InputState.dwKeyPress |= kKeyUp;
-      break;
-
-   case kKeyDown:
-      if (g_InputState.dir != kDirSouth && !fRepeat)
+      else if (key & kKeyLeft)
       {
-         g_InputState.prevdir = (gpGlobals->fInBattle ? kDirUnknown : g_InputState.dir);
-         g_InputState.dir = kDirSouth;
+         iCurrDir = kDirWest;
       }
-      g_InputState.dwKeyPress |= kKeyDown;
-      break;
-
-   case kKeyLeft:
-      if (g_InputState.dir != kDirWest && !fRepeat)
+      else if (key & kKeyUp)
       {
-         g_InputState.prevdir = (gpGlobals->fInBattle ? kDirUnknown : g_InputState.dir);
-         g_InputState.dir = kDirWest;
+         iCurrDir = kDirNorth;
       }
-      g_InputState.dwKeyPress |= kKeyLeft;
-      break;
-
-   case kKeyRight:
-      if (g_InputState.dir != kDirEast && !fRepeat)
+      else if (key & kKeyRight)
       {
-         g_InputState.prevdir = (gpGlobals->fInBattle ? kDirUnknown : g_InputState.dir);
-         g_InputState.dir = kDirEast;
+         iCurrDir = kDirEast;
       }
-      g_InputState.dwKeyPress |= kKeyRight;
-      break;
 
-   default:
-      g_InputState.dwKeyPress |= key;
-      break;
+      if (iCurrDir != kDirUnknown)
+      {
+         g_InputState.dwKeyMaxCount++;
+         g_InputState.dwKeyOrder[iCurrDir] = g_InputState.dwKeyMaxCount;
+         g_InputState.dir = PAL_GetCurrDirection();
+      }
    }
+
+   g_InputState.dwKeyPress |= key;
 }
 
 static VOID
@@ -173,42 +190,31 @@ PAL_KeyUp(
 
 --*/
 {
-   switch (key)
+   INT iCurrDir = kDirUnknown;
+
+   if (key & kKeyDown)
    {
-   case kKeyUp:
-      if (g_InputState.dir == kDirNorth)
-      {
-         g_InputState.dir = g_InputState.prevdir;
-      }
-      g_InputState.prevdir = kDirUnknown;
-      break;
+      iCurrDir = kDirSouth;
+   }
+   else if (key & kKeyLeft)
+   {
+      iCurrDir = kDirWest;
+   }
+   else if (key & kKeyUp)
+   {
+      iCurrDir = kDirNorth;
+   }
+   else if (key & kKeyRight)
+   {
+      iCurrDir = kDirEast;
+   }
 
-   case kKeyDown:
-      if (g_InputState.dir == kDirSouth)
-      {
-         g_InputState.dir = g_InputState.prevdir;
-      }
-      g_InputState.prevdir = kDirUnknown;
-      break;
-
-   case kKeyLeft:
-      if (g_InputState.dir == kDirWest)
-      {
-         g_InputState.dir = g_InputState.prevdir;
-      }
-      g_InputState.prevdir = kDirUnknown;
-      break;
-
-   case kKeyRight:
-      if (g_InputState.dir == kDirEast)
-      {
-         g_InputState.dir = g_InputState.prevdir;
-      }
-      g_InputState.prevdir = kDirUnknown;
-      break;
-
-   default:
-      break;
+   if (iCurrDir != kDirUnknown)
+   {
+      g_InputState.dwKeyOrder[iCurrDir] = 0;
+      iCurrDir = PAL_GetCurrDirection();
+      g_InputState.dwKeyMaxCount = (iCurrDir == kDirUnknown) ? 0 : g_InputState.dwKeyOrder[iCurrDir];
+      g_InputState.dir = iCurrDir;
    }
 }
 

--- a/input.h
+++ b/input.h
@@ -29,6 +29,8 @@ typedef struct tagPALINPUTSTATE
 {
    PALDIRECTION           dir, prevdir;
    DWORD                  dwKeyPress;
+   DWORD                  dwKeyOrder[4];
+   DWORD                  dwKeyMaxCount;
 #if PAL_HAS_JOYSTICKS
    int                    axisX,axisY;
    BOOL                   joystickNeedUpdate;


### PR DESCRIPTION
原始方案存在的问题：
在项目的原始方案中，PC端只记录了当前按下的方向键和上次按的方向键，因此只能记录两次方向，当玩家按下多个方向键（大于2个），然后松开最后按下的那两个方向键后，队员此时会将停止行走，但是玩家此时还在按着其他两个方向键，站在现代游戏的角度来看，这种按键判断方案是非常奇怪的。

新方案做出的优化：
该方案重构了队员行走的按键输入判断，它将记录玩家按方向键的顺序，并根据玩家松开的键来判断上次按的什么键，正确的得出队员该往那个方向走。对比原方案，最大的区别就是它不会出现这种情况：还有别的方向键未弹起呢，队员就已经停止行走了。

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
