### PR TITLE
战斗胜利的结算画面应该允许按任意键跳过

### DIFF
--- a/battle.c
+++ b/battle.c
@@ -1045,7 +1045,7 @@ PAL_BattleWon(
       PAL_DrawNumber(g_Battle.iCashGained, 5, PAL_XY(162, 119), kNumColorYellow, kNumAlignMid);
 
       VIDEO_UpdateScreen(&rect);
-      PAL_WaitForKey(g_Battle.fIsBoss ? 5500 : 3000);
+      PAL_WaitForAnyKey(g_Battle.fIsBoss ? 5500 : 3000);
    }
 
    //
@@ -1215,7 +1215,7 @@ PAL_BattleWon(
          // Update the screen and wait for key
          //
          VIDEO_UpdateScreen(&rect1);
-         PAL_WaitForKey(3000);
+         PAL_WaitForAnyKey(3000);
 
          OrigPlayerRoles = gpGlobals->g.PlayerRoles;
       }
@@ -1269,7 +1269,7 @@ PAL_BattleWon(
       PAL_DrawText(buffer, PAL_XY(offsetX+90, 70),  0, FALSE, FALSE, FALSE); \
       PAL_DrawNumber(gpGlobals->g.PlayerRoles.statname[w] - OrigPlayerRoles.statname[w], 5, PAL_XY(183+(maxNameWidth+maxPropertyWidth-3)*8, 74), kNumColorYellow, kNumAlignRight); \
       VIDEO_UpdateScreen(&rect);                            \
-      PAL_WaitForKey(3000);                                 \
+      PAL_WaitForAnyKey(3000);                              \
    }                                                        \
 }
 
@@ -1321,7 +1321,7 @@ PAL_BattleWon(
             PAL_DrawText(PAL_GetWord(gpGlobals->g.lprgLevelUpMagic[j].m[w].wMagic), PAL_XY(75 + 16 * (w1 + w2) - ww, 115), 0x1B, FALSE, FALSE, FALSE);
 
             VIDEO_UpdateScreen(&rect);
-            PAL_WaitForKey(3000);
+            PAL_WaitForAnyKey(3000);
          }
 
          j++;

--- a/play.c
+++ b/play.c
@@ -580,8 +580,68 @@ PAL_StartFrame(
    }
 }
 
+static inline VOID
+PAL_WaitForKeyInternal(
+   WORD      wTimeOut,
+   BOOL      fAllowAnyKey
+)
+/*++
+  Purpose:
+
+    Wait for any key.
+
+  Parameters:
+
+    [IN]  wTimeOut - the maximum time of the waiting. 0 = wait forever.
+
+    [IN]  fAllowAnyKey - Whether any key are allowed. If no, only KeySearch and KeyMenu allowed.
+
+  Return value:
+
+    None.
+
+--*/
+{
+   DWORD     dwTimeOut = SDL_GetTicks() + wTimeOut;
+
+   PAL_ClearKeyState();
+
+   while (wTimeOut == 0 || !SDL_TICKS_PASSED(SDL_GetTicks(), dwTimeOut))
+   {
+      UTIL_Delay(5);
+
+      if (g_InputState.dwKeyPress && fAllowAnyKey
+         || g_InputState.dwKeyPress & (kKeySearch | kKeyMenu))
+      {
+         break;
+      }
+   }
+}
+
 VOID
 PAL_WaitForKey(
+   WORD      wTimeOut
+)
+/*++
+  Purpose:
+
+    Wait for KeySearch and KeyMenu.
+
+  Parameters:
+
+    [IN]  wTimeOut - the maximum time of the waiting. 0 = wait forever.
+
+  Return value:
+
+    None.
+
+--*/
+{
+   PAL_WaitForKeyInternal(wTimeOut, FALSE);
+}
+
+VOID
+PAL_WaitForAnyKey(
    WORD      wTimeOut
 )
 /*++
@@ -599,17 +659,5 @@ PAL_WaitForKey(
 
 --*/
 {
-   DWORD     dwTimeOut = SDL_GetTicks() + wTimeOut;
-
-   PAL_ClearKeyState();
-
-   while (wTimeOut == 0 || !SDL_TICKS_PASSED(SDL_GetTicks(), dwTimeOut))
-   {
-      UTIL_Delay(5);
-
-      if (g_InputState.dwKeyPress & (kKeySearch | kKeyMenu))
-      {
-         break;
-      }
-   }
+   PAL_WaitForKeyInternal(wTimeOut, TRUE);
 }

--- a/play.h
+++ b/play.h
@@ -51,6 +51,11 @@ PAL_WaitForKey(
    WORD      wTimeOut
 );
 
+VOID
+PAL_WaitForAnyKey(
+   WORD      wTimeOut
+);
+
 PAL_C_LINKAGE_END
 
 #endif


### PR DESCRIPTION
测试的游戏资源版本：
        _Pal dos_
        _Pal Windows 95 3.0 path by louyihua_

经测试，以上两个版本的战斗结算画面都是可以按任意键跳过的。

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
