### PR TITLE
refix: include equipped items when counting quantities of held items in the shop

### DIFF
--- a/uigame.c
+++ b/uigame.c
@@ -1513,7 +1513,7 @@ PAL_BuyMenu_OnItemChange(
 --*/
 {
    const SDL_Rect      rect = {20, 8, 300, 175};
-   int                 i, j, n, x, y;
+   int                 i, j, n, iPlayerID, x, y;
    PAL_LARGE BYTE      bufImage[2048];
 
    //
@@ -1560,9 +1560,11 @@ PAL_BuyMenu_OnItemChange(
 
    for (i = 0; i < MAX_PLAYER_EQUIPMENTS; i++)
    {
-      for (j = 0; j < MAX_PLAYER_ROLES; j++)
+      for (j = 0; j <= gpGlobals->wMaxPartyMemberIndex; j++)
       {
-         if (gpGlobals->g.PlayerRoles.rgwEquipment[i][j] == wCurrentItem) n++;
+         iPlayerID = gpGlobals->rgParty[j].wPlayerRole;
+
+         if (gpGlobals->g.PlayerRoles.rgwEquipment[i][iPlayerID] == wCurrentItem) n++;
       }
    }
 


### PR DESCRIPTION
Continue 4176ade.  Thanks to @rym1020 for reporting the bug.

_**很抱歉，上次修复该问题时未进行较全面的测试，导致商店计算现有数量时会把未入队的队员身上的装备也加进去，现已更正。
感谢 rym1020 报告问题。**_

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
