### PR TITLE
我方队员感染赤毒时，服用九阴散应该将HP恢复满，而不是死亡（2）

### DIFF
--- a/global.c
+++ b/global.c
@@ -1652,6 +1652,15 @@ PAL_IsPlayerPoisonedByLevel(
    for (i = 0; i < MAX_POISONS; i++)
    {
       w = gpGlobals->rgPoisonStatus[i][index].wPoisonID;
+
+      if (w == 0)
+      {
+         //
+         // Skip empty PoisonID
+         //
+         continue;
+      }
+
       w = gpGlobals->g.rgObject[w].poison.wPoisonLevel;
 
       if (w >= 99)


### PR DESCRIPTION
问题描述：
        经上次的修复，九阴散已无法区分player到底有没有中毒，服用后变成直接将HP恢复满了。

原因：
        赤毒本就是0级，而在没有中毒的状态下，所有的中毒状态的 PoisonLevel 值都是 0，导致判断出player默认中赤毒。

解决方案：
        在中毒判断时跳过了 PoisonID 值为 0 的项，详见 <[Files changed](https://github.com/sdlpal/sdlpal/pull/297/files)>。

感谢 @palleaf 反馈。

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
