### PR TITLE
fix: Exorcism-Incense will cause monsters to spin in place

### DIFF
--- a/script.c
+++ b/script.c
@@ -483,6 +483,19 @@ PAL_MonsterChasePlayer(
          }
       }
    }
+   else
+   {
+      //
+      // Exorcism-Fragrance will cause monsters to spin in place
+      // Switch direction every two frames
+      //
+      if (gpGlobals->dwFrameNum & 1)
+      {
+         pEvtObj->wDirection++;
+
+         if (pEvtObj->wDirection > 3) pEvtObj->wDirection = 0;
+      }
+   }
 
    PAL_NPCWalkOneStep(wEventObjectID, wMonsterSpeed);
 }


### PR DESCRIPTION
已为 Isues-#294 提供了解决方案：
        在事件重置帧号为 0 时加了判断，若敌人追逐范围为 0，则方向值增加 1

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
