### PR TITLE
队伍中只有一人时，应直接打开此队员的法术菜单

### DIFF
--- a/uigame.c
+++ b/uigame.c
@@ -674,6 +674,12 @@ PAL_InGameMagicMenu(
    static WORD      w;
    WORD             wMagic;
 
+   if (gpGlobals->wMaxPartyMemberIndex == 0)
+   {
+      w = gpGlobals->rgParty[0].wPlayerRole;
+      goto start_magicmenu;
+   }
+
    //
    // Draw the player info boxes
    //
@@ -716,6 +722,8 @@ PAL_InGameMagicMenu(
    {
       return;
    }
+
+start_magicmenu:
 
    wMagic = 0;
 


### PR DESCRIPTION
在原版中，若队伍中只有一人，按F或在ESC菜单中选择仙术菜单，不会出现队员选择菜单，而是直接打开了该队员的法术菜单。
以下为sdlpal的效果
![QQ图片20240719093002](https://github.com/user-attachments/assets/d9a0e799-d805-4cdf-84da-e0ee66fc8da2)


- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [x] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
