### PR TITLE
在原生PAL中，每过一帧，只有当前场景下消失的怪物（事件对象）需要递减复活CD

### DIFF
--- a/play.c
+++ b/play.c
@@ -76,19 +76,6 @@ PAL_GameUpdate(
       }
 
       //
-      // Update the vanish time for all event objects
-      //
-      for (wEventObjectID = 0; wEventObjectID < gpGlobals->g.nEventObject; wEventObjectID++)
-      {
-         p = &gpGlobals->g.lprgEventObject[wEventObjectID];
-
-         if (p->sVanishTime != 0)
-         {
-            p->sVanishTime += ((p->sVanishTime < 0) ? 1 : -1);
-         }
-      }
-
-      //
       // Loop through all event objects in the current scene
       //
       for (wEventObjectID = gpGlobals->g.rgScene[gpGlobals->wNumScene - 1].wEventObjectIndex + 1;
@@ -99,6 +86,10 @@ PAL_GameUpdate(
 
          if (p->sVanishTime != 0)
          {
+            //
+            // Update the vanish time for all event objects
+            //
+            p->sVanishTime += ((p->sVanishTime < 0) ? 1 : -1);
             continue;
          }
 


### PR DESCRIPTION
在原生PAL中，每过一帧，只有当前场景下消失的怪物（事件对象）需要递减复活CD，而 sdlpal 却把整个游戏所有怪物的复活CD都递减了。

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [x] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
