### PR TITLE
脚本控制播放RNG动画，末尾帧参数未缺省时少播放了一帧（末尾帧）

### DIFF
--- a/rngplay.c
+++ b/rngplay.c
@@ -401,9 +401,15 @@ PAL_RNGPlay(
    uint8_t        *buf = (uint8_t *)malloc(65000);
    FILE           *fp = UTIL_OpenRequiredFile("rng.mkf");
 
+   //
+   // Avoid losing the last frame
+   //
+   if (iEndFrame > 0) iEndFrame++;
+
    for (double iTime = SDL_GetPerformanceCounter(); rng && buf && iStartFrame != iEndFrame; iStartFrame++)
    {
-	  iTime += iDelay;
+      iTime += iDelay;
+
       //
       // Read, decompress and render the frame
       //


### PR DESCRIPTION
脚本控制播放RNG动画，末尾帧参数未缺省时少播放了一帧（末尾帧）
此问题顺便导致了 WIN 版资源下播放 [RNG4: 林月如殒命](https://github.com/palxex/palresearch/blob/master/PalScript/MovieID.txt#L6) 时出现了后面的石板坠落帧没有背景色的问题，经测试，原来是sdlpal少播放了最后一帧。


重现前准备：（附件中已提供修改后的文件）
> **修改拜月战后的拜月跳水池脚本，**
> 原：1号帧播放到16号帧
> 现修改后：靠近拜月，直接跳转到动画播放脚本处，1号帧播放到17号帧

重现方法：
1. PAL.EXE在补丁设置中关闭除错修正
2. 使用附件中的SSS.MKF覆盖WIN版的SSS.MKF
3. 运行PAL.EXE，读取附件中的进度二，与桥上拜月对话
4. 当对话播放到此处时分别使用sdlpal和PAL.EXE进行截图对比：
![SDLPAL](https://github.com/user-attachments/assets/c55b8ba3-933a-48ec-a9bb-2b24fc7f5ce7)
![PAL](https://github.com/user-attachments/assets/384a5cf5-3d40-476a-a5ea-818af6a779c9)
5. 此时可见两程序播放结果不同

附件：

> [pr_demo.zip](https://github.com/user-attachments/files/16808164/pr_demo.zip)


- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
