### PR TITLE
原版升级后的体力真气提升的浮动值不同

### DIFF
--- a/global.c
+++ b/global.c
@@ -2378,8 +2378,8 @@ PAL_PlayerLevelUp(
       //
       // Increase player's stats
       //
-      gpGlobals->g.PlayerRoles.rgwMaxHP[wPlayerRole] += 10 + RandomLong(0, 8);
-      gpGlobals->g.PlayerRoles.rgwMaxMP[wPlayerRole] += 8 + RandomLong(0, 6);
+      gpGlobals->g.PlayerRoles.rgwMaxHP[wPlayerRole] += 10 + RandomLong(0, 7);
+      gpGlobals->g.PlayerRoles.rgwMaxMP[wPlayerRole] += 8 + RandomLong(0, 5);
       gpGlobals->g.PlayerRoles.rgwAttackStrength[wPlayerRole] += 4 + RandomLong(0, 1);
       gpGlobals->g.PlayerRoles.rgwMagicStrength[wPlayerRole] += 4 + RandomLong(0, 1);
       gpGlobals->g.PlayerRoles.rgwDefense[wPlayerRole] += 2 + RandomLong(0, 1);


### PR DESCRIPTION
对原生DOS版和WIN版PAL.EXE进行了吃金蚕王升级测试，得出属性提升浮动值结论：
体力：10 ~ 17（sdlpal是10 ~ 18）
真气：8 ~ 13（sdlpal是8 ~ 14）
武：4 ~ 5
灵：4 ~ 5
防：2 ~ 3
速：2 ~ 3
逃：2

附件：（测试存档）
[pr_306.zip](https://github.com/user-attachments/files/16917261/pr_306.zip)

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
