### PR TITLE
敌方受乱定眠影响时，本回合不该执行此敌人的回合行动脚本

### DIFF
--- a/fight.c
+++ b/fight.c
@@ -1716,8 +1716,17 @@ PAL_BattleStartFrame(
             if (g_Battle.iHidingTime == 0 && !fOnlyPuppet &&
                g_Battle.rgEnemy[i].wObjectID != 0)
             {
-               g_Battle.rgEnemy[i].wScriptOnReady =
-                  PAL_RunTriggerScript(g_Battle.rgEnemy[i].wScriptOnReady, i);
+               if (g_Battle.rgEnemy[i].rgwStatus[kStatusConfused] == 0 &&
+                  g_Battle.rgEnemy[i].rgwStatus[kStatusParalyzed] == 0 &&
+                  g_Battle.rgEnemy[i].rgwStatus[kStatusSleep] == 0)
+               {
+                  //
+                  // When it is detected that the enemy is in a bad state,
+                  // the enemy's ready-to-action script will not be executed in this turn.
+                  //
+                  g_Battle.rgEnemy[i].wScriptOnReady =
+                     PAL_RunTriggerScript(g_Battle.rgEnemy[i].wScriptOnReady, i);
+               }
 
                g_Battle.fEnemyMoving = TRUE;
                PAL_BattleEnemyPerformAction(i);


### PR DESCRIPTION
资源：
DOSBOX Ver 0.72.0.0 中运行仙剑 DOS 版
Pal Windows 95 3.0 补丁 By Yihua Lou

源项目出现的问题：
在原版游戏中，敌方受 **_乱定眠_** 影响时，本回合不会执行此敌人的 _**回合行动脚本（ScriptOnReady）**_ 。
在sdlpal中，敌方受 **_乱定眠_** 影响时，本回合依然会执行此敌人的 _**回合行动脚本（ScriptOnReady）**_ 。

 源项目问题的重现方式：（ **_[DOS版测试补丁 pr_311_demo_dos.zip](https://github.com/user-attachments/files/18436461/pr_311_demo_dos.zip)_** ）
将六角蜘蛛（蜘蛛精）、赤鬼王的巫抗设置为0，将黑狗血改为投掷 _**咒封 3 回合**_ ，丢道具进行特殊状态测试。
六角蜘蛛（蜘蛛精）的测试结果，sdlpal与原生pal一致。
赤鬼王的测试结果（以开局投掷忘魂花为例），sdlpal的赤鬼王的会在 _**昏睡 3 回合**_ 后直接出招 **_血魔神功_** ，原生pal的赤鬼王则是 _**昏睡 3 回合**_ 之后 _**平A　平A　召唤**_

赤鬼王出招表：
![image](https://github.com/user-attachments/assets/0ce77895-53b2-4957-9184-6d1576b9eb2c)

结论：
必败战的敌方出招表和回合出招前对话都是在 **_wScriptOnTurnStart（本回合开始时执行的脚本）_** 中的，此类型脚本不会受**乱定眠**的影响。
非必败战的敌方出招表都是在 **_wScriptOnReady（本回合结束时执行的脚本）_** 中的，此类型脚本受 _**乱定眠**_ 影响，只要该敌人有其中的一种状态，则该回合不会执行此敌人的 **_wScriptOnReady（本回合结束时执行的脚本）_** 

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
