### PR TITLE
joystick hot plug supporting

### DIFF
--- a/input.c
+++ b/input.c
@@ -90,7 +90,7 @@ static const int g_KeyMap[][2] = {
    { SDLK_s,         kKeyStatus }
 };
 
-
+#if PAL_HAS_JOYSTICKS
 static VOID
 PAL_DetectJoystick(
     VOID
@@ -135,6 +135,7 @@ PAL_DetectJoystick(
         g_pJoy = NULL;
     }
 }
+#endif
 
 static INT
 PAL_GetCurrDirection(

--- a/input.c
+++ b/input.c
@@ -90,6 +90,52 @@ static const int g_KeyMap[][2] = {
    { SDLK_s,         kKeyStatus }
 };
 
+
+static VOID
+PAL_DetectJoystick(
+    VOID
+)
+/*++
+  Purpose:
+
+    Detect the joystick.
+
+  Parameters:
+
+    None.
+
+  Return value:
+
+    None.
+
+--*/
+{
+    if (SDL_NumJoysticks() > 0 && g_fUseJoystick)
+    {
+        int i;
+        for (i = 0; i < SDL_NumJoysticks(); i++)
+        {
+            if (PAL_IS_VALID_JOYSTICK(SDL_JoystickNameForIndex(i)))
+            {
+                g_pJoy = SDL_JoystickOpen(i);
+                break;
+            }
+        }
+
+        if (g_pJoy != NULL)
+        {
+            //
+            //! CANNOT BE DISABLED OR HOTPLUG STOPS WORK
+            //
+            SDL_JoystickEventState(SDL_ENABLE);
+        }
+    }
+    else
+    {
+        g_pJoy = NULL;
+    }
+}
+
 static INT
 PAL_GetCurrDirection(
    VOID
@@ -548,6 +594,10 @@ PAL_JoystickEventFilter(
 #if PAL_HAS_JOYSTICKS
    switch (lpEvent->type)
    {
+   case SDL_JOYDEVICEADDED:
+   case SDL_JOYDEVICEREMOVED:
+       PAL_DetectJoystick();
+       break;
    case SDL_JOYAXISMOTION:
       g_InputState.joystickNeedUpdate = TRUE;
       //
@@ -1105,29 +1155,6 @@ PAL_InitInput(
    memset((void *)&g_InputState, 0, sizeof(g_InputState));
    g_InputState.dir = kDirUnknown;
    g_InputState.prevdir = kDirUnknown;
-
-   //
-   // Check for joystick
-   //
-#if PAL_HAS_JOYSTICKS
-   if (SDL_NumJoysticks() > 0 && g_fUseJoystick)
-   {
-      int i;
-	  for (i = 0; i < SDL_NumJoysticks(); i++)
-      {
-         if (PAL_IS_VALID_JOYSTICK(SDL_JoystickNameForIndex(i)))
-         {
-            g_pJoy = SDL_JoystickOpen(i);
-            break;
-         }
-      }
-
-      if (g_pJoy != NULL)
-      {
-         SDL_JoystickEventState(SDL_ENABLE);
-      }
-   }
-#endif
 
    input_init_filter();
 }

--- a/input.c
+++ b/input.c
@@ -1157,6 +1157,14 @@ PAL_InitInput(
    g_InputState.dir = kDirUnknown;
    g_InputState.prevdir = kDirUnknown;
 
+   //
+   // Check for joystick
+   // MUST FOR PLATFORMS THAT DOES NOT SUPPORT JOYSTICKS HOTPLUG
+   //
+#if PAL_HAS_JOYSTICKS
+   PAL_DetectJoystick();
+#endif
+
    input_init_filter();
 }
 


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

Sure
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

It's intended to enable SDLPal from supporting joysticks hotplugging on supported platforms. Previous SDLPal can only make use of joysticks that was already plugged in whenever the game launches. After applying this patch, joysticks that plugged in during the game session will also available to use, while not disturbing existing KB player. 
- [x] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

No, just make use of existing SDL functions.
Supported platforms（via grepping in SDL code）: android/macOS/iOS/windows/vita/hidapi/virtual. 
- [x] Have you written new tests for your changes?

No, I don't think its possible.
- [x] Have you successfully run it with your changes locally?

Yeah, the only limitation is that I just owned one joystick, so multiple joystick hotplug in/out cannot be tested. The PR intended to only use the 1st available joystick that SDL detected, exactly like behavior before it's applied.
- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [x] Android
  - [x] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3（or any later version at the choice of the maintainers of the SDLPAL Project） as published by the Free Software Foundation.
