### PR TITLE
脚本指令 0x0020 在特定情况下会错误地移除队员身上的装备

### DIFF
--- a/global.c
+++ b/global.c
@@ -1151,6 +1151,7 @@ PAL_AddItemToInventory(
             //
             // This item has been run out
             //
+            gpGlobals->nLastRemovedItem = gpGlobals->rgInventory[index].nAmount;
             gpGlobals->rgInventory[index].nAmount = 0;
             return FALSE;
          }

--- a/global.h
+++ b/global.h
@@ -540,6 +540,7 @@ typedef struct tagGLOBALVARS
    WORD             wChaseRange;
    WORD             wChasespeedChangeCycles;
    USHORT           nFollower;
+   SHORT            nLastRemovedItem;    // The number of items removed last time in the inventory
 
    DWORD            dwCash;              // amount of cash
 

--- a/script.c
+++ b/script.c
@@ -985,31 +985,33 @@ PAL_InterpretInstruction(
       }
       if (x <= PAL_CountItem(pScript->rgwOperand[0]) || pScript->rgwOperand[2] == 0)
       {
-      if (!PAL_AddItemToInventory(pScript->rgwOperand[0], -x))
-      {
-         //
-         // Try removing equipped item
-         //
-         for (i = 0; i <= gpGlobals->wMaxPartyMemberIndex; i++)
+         if (!PAL_AddItemToInventory(pScript->rgwOperand[0], -x))
          {
-            w = gpGlobals->rgParty[i].wPlayerRole;
+            x -= gpGlobals->nLastRemovedItem;
 
-            for (j = 0; j < MAX_PLAYER_EQUIPMENTS; j++)
+            //
+            // Try removing equipped item
+            //
+            for (i = 0; i <= gpGlobals->wMaxPartyMemberIndex; i++)
             {
-               if (gpGlobals->g.PlayerRoles.rgwEquipment[j][w] == pScript->rgwOperand[0])
-               {
-                  PAL_RemoveEquipmentEffect(w, j);
-                  gpGlobals->g.PlayerRoles.rgwEquipment[j][w] = 0;
+               w = gpGlobals->rgParty[i].wPlayerRole;
 
-                  if (--x == 0)
+               for (j = 0; j < MAX_PLAYER_EQUIPMENTS; j++)
+               {
+                  if (gpGlobals->g.PlayerRoles.rgwEquipment[j][w] == pScript->rgwOperand[0])
                   {
-                     i = 9999;
-                     break;
+                     PAL_RemoveEquipmentEffect(w, j);
+                     gpGlobals->g.PlayerRoles.rgwEquipment[j][w] = 0;
+
+                     if (--x == 0)
+                     {
+                        i = 9999;
+                        break;
+                     }
                   }
                }
             }
          }
-      }
       }
       else
           wScriptEntry = pScript->rgwOperand[2] - 1;


### PR DESCRIPTION
### **_重现方式（DOS版重现补丁已打包到附件）：_**
1.将十年前小逍遥向玩家索要的木剑数改为 7（DOS版SSS.MKF地址：0x0007f698）
2.库存中有木剑 * 5
3.队伍中有三名队员且每人都装备木剑

### **_sdlpal 重现结果：_**
库存中木剑全部被移除，全体队员装备的木剑都被移除

### ** _DOS原版重新结果：_**
库存中木剑全部被移除，前两名队员装备的木剑被移除

### **_附件：_**
[pr_script_remove_item.zip](https://github.com/user-attachments/files/20139572/pr_script_remove_item.zip)

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
