### PR TITLE
脚本指令 0x0086 需要检查所有队员身上是否有多个相同的装备

### DIFF
--- a/script.c
+++ b/script.c
@@ -2519,7 +2519,7 @@ PAL_InterpretInstruction(
       //
       // Jump if the specified item is not equipped
       //
-      y = FALSE;
+      y = 0;
       for (i = 0; i <= gpGlobals->wMaxPartyMemberIndex; i++)
       {
          w = gpGlobals->rgParty[i].wPlayerRole;
@@ -2527,13 +2527,11 @@ PAL_InterpretInstruction(
          {
             if (gpGlobals->g.PlayerRoles.rgwEquipment[x][w] == pScript->rgwOperand[0])
             {
-               y = TRUE;
-               i = 999;
-               break;
+               y++;
             }
          }
       }
-      if (!y)
+      if (y < pScript->rgwOperand[1])
       {
          wScriptEntry = pScript->rgwOperand[2] - 1;
       }


### PR DESCRIPTION
### **_重现方式（DOS版重现补丁与存档已打包到附件）：_**
将进入将军冢需要装备的玉佛珠数改为 7（DOS版SSS.MKF地址：0x000555f0）

### **_sdlpal 重现结果：_**
队员身上有 1 个玉佛珠就能进入将军冢

### ** _DOS原版重现结果：_**
队员身上共计有 7 个玉佛珠才能进入将军冢

### **_附件：_**
[pr_script_0x0086_dos.zip](https://github.com/user-attachments/files/20433709/pr_script_0x0086_dos.zip)

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
