### PR TITLE
fix-PAL_InGameMagicMenu-logic

### DIFF
--- a/uigame.c
+++ b/uigame.c
@@ -676,7 +676,7 @@ PAL_InGameMagicMenu(
 
    if (gpGlobals->wMaxPartyMemberIndex == 0)
    {
-      w = gpGlobals->rgParty[0].wPlayerRole;
+      w = 0;
       goto start_magicmenu;
    }
 


### PR DESCRIPTION
In PAL_InGameMagicMenu, when there’s only one party member (gpGlobals->wMaxPartyMemberIndex == 0), you do:
w = gpGlobals->rgParty[0].wPlayerRole; goto start_magicmenu;
But at start_magicmenu you call:
PAL_MagicSelectionMenu(gpGlobals->rgParty[w].wPlayerRole, FALSE, wMagic);
Here w is actually the character ID, not the party index. When there’s only one character, w should remain the party index 0 and not be used to select which character.

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?
<img width="320" height="200" alt="20250721234245750" src="https://github.com/user-attachments/assets/6d867891-79d3-4ad6-8a54-aaa746694b85" />
<img width="320" height="200" alt="20250721234325375" src="https://github.com/user-attachments/assets/468c43b6-9be2-46c7-a52e-5fd74bef227e" />

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
