### PR TITLE
fix-script -0x0086

### DIFF
--- a/script.c
+++ b/script.c
@@ -1,4 +1,4 @@
-/* -*- mode: c; tab-width: 4; c-basic-offset: 4; c-file-style: "linux" -*- */
+﻿/* -*- mode: c; tab-width: 4; c-basic-offset: 4; c-file-style: "linux" -*- */
 //
 // Copyright (c) 2009-2011, Wei Mingzhi <whistler_wmz@users.sf.net>.
 // Copyright (c) 2011-2024, SDLPAL development team.
@@ -2519,6 +2519,8 @@ PAL_InterpretInstruction(
       //
       // Jump if the specified item is not equipped
       //
+      if (pScript->rgwOperand[1] == 0) 
+           pScript->rgwOperand[1] = 1;
       y = 0;
       for (i = 0; i <= gpGlobals->wMaxPartyMemberIndex; i++)
       {


### PR DESCRIPTION
you prevent the case where the required count is 0. Previously, the condition if (y < 0) could never be true, so the jump never executed.
 Now, if the script doesn’t specify a required count, it defaults to 1. That means “jump if nobody has this item equipped” works as intended.

- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same change?

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

- [ ] How many dependencies was introduced in this PR? Did the minimal requirement changed, for which platform?

- [x] Have you written new tests for your changes?

- [x] Have you successfully run it with your changes locally?

- [x] Have you tested on following platforms?
  - [x] Win32
  - [ ] UWP
  - [ ] Linux
  - [ ] Android
  - [ ] macOS
  - [ ] iOS

- [x] I certify that I have the right and agree to submit my contributions under the terms of GNU General Public License, version 3 (or any later version at the choice of the maintainers of the SDLPAL Project) as published by the Free Software Foundation.
